### PR TITLE
Added an internal package for parsing command-line flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added draft working version
 - Added the project description (README.md)
+- An internal package for parsing command-line flags.
 
 ### Fixed
 - Fixed newline convention CRLF -> LF
+- The application now correctly exits if the server fails to start.

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,0 +1,28 @@
+package flags
+
+import (
+	"flag"
+	"strconv"
+)
+
+type Flags struct {
+	CacheDir    string
+	UpstreamURL string
+	Port        int
+	IP          string
+}
+
+func NewFlags() (f Flags) {
+	flag.StringVar(&f.CacheDir, "cache-dir", "./", "Directory to store cache")
+	flag.StringVar(&f.UpstreamURL, "upstream-url", "https://ziglang.org", "Zig upstream mirror")
+	flag.IntVar(&f.Port, "port", 8080, "Port to listen on")
+	flag.StringVar(&f.IP, "ip", "", "IP to listen on")
+
+	flag.Parse()
+
+	return f
+}
+
+func (f Flags) Address() string {
+	return f.IP + ":" + strconv.Itoa(f.Port)
+}


### PR DESCRIPTION
## Description
Added:
- An internal package for parsing command-line flags.

Fixed:
- The application now correctly exits if the server fails to start.
