### PR TITLE
TLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added the project description (README.md)
 - An internal package for parsing command-line flags.
 - Comments to the Config package.
+- Now it is possible to start a secure server (TLS, HTTPS).
+- New config parameters that are responsible for HTTP/HTTPS ports, TLS cert/key files, redirect behavior.
+- Ability to redirect incoming requests from http-port (default 80) to tls-port (default 443).
 
 ### Fixed
 - Fixed newline convention CRLF -> LF
 - The application now correctly exits if the server fails to start.
+- Servers (http, tls, redirect) start and stop correctly
 
 ### Changed
 - The package Flags renamed to Config.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,24 @@ Contributions are welcomed!
 ```
 Usage of go-mirror-zig:
   -cache-dir string
-        Directory to store cache (default "./")
-  -ip string
-        IP to listen on
-  -port int
-        Port to listen on (default 8080)
+        Path to the directory where downloaded content will be cached. (default "./")
+  -enable-tls
+        Enable the TLS (HTTPS) server. Requires -tls-cert-file and -tls-key-file.
+  -http-port int
+        The port for the plain HTTP listener. (default 80)
+  -listen-address string
+        The IP address to listen on. If empty, listens on all available interfaces.
+  -redirect-to-https
+        Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls.
+  -tls-cert-file string
+        Path to the TLS certificate file.
+  -tls-key-file string
+        Path to the TLS private key file.
+  -tls-port int
+        The port for the secure TLS (HTTPS) listener. (default 443)
   -upstream-url string
-        Zig upstream mirror (default "https://ziglang.org")
+        The URL of the upstream server to mirror/proxy. (default "https://ziglang.org")
+
 ```
 
 An example of integration the application with Systemd:

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+)
+
+func RedirectHandler(port int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// net.SplitHostPort to safely extract the hostname without the port.
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			host = r.Host
+		}
+
+		targetURL := "https://" + host + ":" + strconv.Itoa(port) + r.URL.RequestURI()
+
+		slog.Info(
+			"redirecting http to https",
+			"remote_ip", GetRemoteIP(*r),
+			"method", r.Method,
+			"host", r.Host,
+			"path", r.URL.Path,
+			"target", targetURL,
+		)
+
+		http.Redirect(w, r, targetURL, http.StatusMovedPermanently)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,30 @@
 package config
 
 import (
+	"crypto/tls"
+	"errors"
 	"flag"
+	"fmt"
 	"net"
 	"strconv"
 )
 
 // Config holds configuration values, populated from command-line flags.
 type Config struct {
-	CacheDir      string
-	UpstreamURL   string
-	HTTPPort      int
-	ListenAddress string
+	CacheDir        string
+	UpstreamURL     string
+	HTTPPort        int
+	TLSPort         int
+	ListenAddress   string
+	EnableTLS       bool
+	RedirectToHTTPS bool
+
+	// KeyPair is the loaded TLS certificate and key. It is only populated if EnableTLS is true.
+	KeyPair tls.Certificate
+
+	// unexported fields for parsing flags before validation.
+	tlsCertFile string
+	tlsKeyFile  string
 }
 
 // ParseConfig defines and parses command-line flags, validates them, and returns a populated Config struct.
@@ -21,9 +34,30 @@ func ParseConfig() (Config, error) {
 	flag.StringVar(&c.CacheDir, "cache-dir", "./", "Path to the directory where downloaded content will be cached.")
 	flag.StringVar(&c.UpstreamURL, "upstream-url", "https://ziglang.org", "The URL of the upstream server to mirror/proxy.")
 	flag.IntVar(&c.HTTPPort, "http-port", 80, "The port for the plain HTTP listener.")
+	flag.IntVar(&c.TLSPort, "tls-port", 443, "The port for the secure TLS (HTTPS) listener.")
 	flag.StringVar(&c.ListenAddress, "listen-address", "", "The IP address to listen on. If empty, listens on all available interfaces.")
+	flag.BoolVar(&c.EnableTLS, "enable-tls", false, "Enable the TLS (HTTPS) server. Requires -tls-cert-file and -tls-key-file.")
+	flag.StringVar(&c.tlsCertFile, "tls-cert-file", "", "Path to the TLS certificate file.")
+	flag.StringVar(&c.tlsKeyFile, "tls-key-file", "", "Path to the TLS private key file.")
+	flag.BoolVar(&c.RedirectToHTTPS, "redirect-to-https", false, "Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls.")
 
 	flag.Parse()
+
+	if c.EnableTLS {
+		if c.tlsKeyFile == "" || c.tlsCertFile == "" {
+			return c, errors.New("to enable TLS, both -tls-cert-file and -tls-key-file flags must be provided")
+		}
+
+		keyPair, err := tls.LoadX509KeyPair(c.tlsCertFile, c.tlsKeyFile)
+		if err != nil {
+			return c, fmt.Errorf("failed to load TLS key pair: %w", err)
+		}
+		c.KeyPair = keyPair
+	}
+
+	if c.RedirectToHTTPS && !c.EnableTLS {
+		return c, errors.New("-redirect-to-https requires -enable-tls to be set")
+	}
 
 	return c, nil
 }
@@ -31,4 +65,9 @@ func ParseConfig() (Config, error) {
 // HTTPAddress returns the full address for the HTTP server.
 func (c Config) HTTPAddress() string {
 	return net.JoinHostPort(c.ListenAddress, strconv.Itoa(c.HTTPPort))
+}
+
+// HTTPSAddress returns the full address for the HTTPS server.
+func (c Config) HTTPSAddress() string {
+	return net.JoinHostPort(c.ListenAddress, strconv.Itoa(c.TLSPort))
 }


### PR DESCRIPTION
## Description
Added:
- Now it is possible to start a secure server (TLS, HTTPS).
- New config parameters that are responsible for HTTP/HTTPS ports, TLS cert/key files, redirect behavior.
- Ability to redirect incoming requests from http-port (default 80) to tls-port (default 443).

Fixed:
- Servers (http, tls, redirect) start and stop correctly