### PR TITLE
New cache directory layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Now it is possible to start a secure server (TLS, HTTPS).
 - New config parameters that are responsible for HTTP/HTTPS ports, TLS cert/key files, redirect behavior.
 - Ability to redirect incoming requests from http-port (default 80) to tls-port (default 443).
+- The server can act as a caching upstream mirror. Now it allows serving files
+  on `/builds/*` and `/download/*/*` paths. Can be useful if you want to daisy
+  chain server.
 
 ### Fixed
 - Fixed newline convention CRLF -> LF
@@ -26,3 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Handlers log more information about requests and server tasks.
 - Reduced amount of logging information. Middleware and redirect handlers don't
   log any data anymore. Added 'source' field to the cache handler's logger.
+- Cache directory layout for cached files. Previously all files were put in a
+  root cache directory (that is set by `--cache-dir` flag), but now they follow
+  the official Zig download layout. Dev builds are now stored in `/builds/` and
+  release builds are stored in `/downloads/*/`.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,8 @@ func run() error {
 	mux.HandleFunc("/", handlers.RootHandler(tmpl))
 	mux.HandleFunc("/{file}", cache.Handler())
 	mux.HandleFunc("/zig/{file}", cache.Handler())
+	mux.HandleFunc("/builds/{file}", cache.Handler())
+	mux.HandleFunc("/download/", cache.Handler())
 	mainHandler := handlers.Middleware(mux)
 
 	var servers []*http.Server


### PR DESCRIPTION
## Description
The server can act as a caching upstream mirror. Now it allows serving files on `/builds/*` and `/download/*/*` paths. Can be useful if you want to daisy chain server.

Cache directory layout for cached files. Previously all files were put in a root cache directory (that is set by `--cache-dir` flag), but now they follow the official Zig download layout. Dev builds are now stored in `/builds/` and release builds are stored in `/downloads/*/`.