### PR TITLE
Added a build script for cross-compiling releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binary
 go-mirror-zig
+build/release
 
 # Visual Studio Code
 # Ignore all files in .vscode except for the team-shared settings and recommendations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added new sections in the readme: Getting Started, Examples, Configuration, Deployment, Contributing, Licenses and Acknowledgements.
 - Added version information flag support, updated readme.
 - Added a make script for building the application.
+- Added a build script for cross-compiling releases.
+- Compiled releases are not tracked by git.
+- Added 'From a Precompiled Binary' section in readme.
 
 ### Fixed
 - Fixed newline convention CRLF -> LF

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCES := $(wildcard *.go cmd/*/*.go)
 
-VERSION=$(shell git describe --tags --always --dirty)
+VERSION=$(shell git describe --tags --always --dirty  --long)
 
 build: $(SOURCES)
 	go build -ldflags "-X main.version=${VERSION}" -o go-mirror-zig ./cmd/main.go

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ It is lightweight and distributed as a single binary.
 * Path correctness: Caches files using the official Zig directory layout (`/download/<version>/` and `/builds/`).
 
 ## Getting Started
+### From a Precompiled Binary
+This is the recommended method for most users.
+1.  Navigate to the [latest release page](https://github.com/savalione/go-mirror-zig/releases/latest).
+2.  Download the archive for your operating system and architecture (e.g., `go-mirror-zig-v1.0.0-linux-amd64.tar.gz`).
+3.  Extract the archive.
+    ```sh
+    tar -xvzf go-mirror-zig-v1.0.0-linux-amd64.tar.gz
+    ```
+4.  Run the application. You can verify it's working by checking the version or help output.
+    ```sh
+    ./go-mirror-zig --version
+    ```
+
 ### From source
 Ensure you have a recent version of Go installed.
 1.  Clone the repository:

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+VERSION=$(git describe --tags --always --dirty --long)
+MAIN_PACKAGE="../cmd/main.go"
+OUTPUT_NAME="go-mirror-zig"
+
+mkdir -p release
+
+# Target platforms.
+PLATFORMS=(
+    "linux/amd64"
+    "linux/arm64"
+    "windows/amd64"
+    "darwin/amd64"
+    "darwin/arm64"
+)
+
+echo "Building release artifacts for version ${VERSION}..."
+
+for platform in "${PLATFORMS[@]}"; do
+    GOOS=$(dirname "${platform}")
+    GOARCH=$(basename "${platform}")
+
+    OUTPUT_FILENAME="${OUTPUT_NAME}-${GOOS}-${GOARCH}"
+    if [ "${GOOS}" = "windows" ]; then
+        OUTPUT_FILENAME="${OUTPUT_FILENAME}.exe"
+    fi
+
+    echo "Building for ${GOOS}/${GOARCH}..."
+
+    # Build the binary with version information.
+    # The -s and -w flags strip debugging information, reducing the binary size.
+    env GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags="-s -w -X main.version=${VERSION}" -o "release/${OUTPUT_FILENAME}" ${MAIN_PACKAGE}
+
+    cd release
+    tar -czvf "${OUTPUT_NAME}-${VERSION}-${GOOS}-${GOARCH}.tar.gz" "${OUTPUT_FILENAME}"
+    rm "${OUTPUT_FILENAME}"
+    cd ..
+done
+
+echo "Build complete. Artifacts are in the 'release' directory."


### PR DESCRIPTION
## Description
- Added a build script for cross-compiling releases.
- Compiled releases are not tracked by git.
- Added 'From a Precompiled Binary' section in readme.