### PR TITLE
Customizable index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `-show-index-page` and `-index-page` flags to allow users to customize or disable the root index page.
+
 ### Security
 - Updated `golang.org/x/crypto` library (`v0.41.0` -> `v0.49.0`) (thanks dependabot for that)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is lightweight and distributed as a single binary.
 * Standalone binary: Compiles to a single, dependency-free binary for easy deployment.
 * Configurable: All settings are manageable via command-line flags, including ports, cache directories, and upstream URL.
 * Path correctness: Caches files using the official Zig directory layout (`/download/<version>/` and `/builds/`).
+* Customizable index page: Serve a custom landing page or static directory at the root, with option to completely disable the default index.
 
 ## Getting Started
 ### From a Precompiled Binary
@@ -103,24 +104,26 @@ go-mirror-zig -acme -acme-accept-tos -acme-cache /secure-location -acme-email us
 The application is configured using command-line flags.
 Run `./go-mirror-zig -help` to see all available options.
 
-|Flag                    |Description                                                                               |Default value        |
-|:-----------------------|:-----------------------------------------------------------------------------------------|:--------------------|
-|`-acme`                 |Obtain TLS certificates using the ACME challenge.                                         |                     |
-|`-acme-accept-tos`      |Accept the ACME provider's Terms of Service.                                              |                     |
-|`-acme-cache string`    |Directory for storing obtained certificates.                                              |                     |
-|`-acme-directory string`|ACME directory URL.                                                                       |`https://acme-v02.api.letsencrypt.org/directory`|
-|`-acme-email string`    |Email address for ACME registration and recovery notices.                                 |                     |
-|`-acme-host string`     |The hostname (domain name) for which to obtain the ACME certificate.                      |                     |
-|`-cache-dir string`     |Path to the directory where downloaded content will be cached.                            |`./`                 |
-|`-enable-tls`           |Enable the TLS (HTTPS) server. Requires `-tls-cert-file` and `-tls-key-file`.             |                     |
-|`-http-port int`        |The port for the plain HTTP listener.                                                     |`80`                 |
-|`-listen-address string`|The IP address to listen on. If empty, listens on all available interfaces.               |                     |
-|`-redirect-to-https`    |Enable automatic redirection of HTTP requests to HTTPS. Requires `-enable-tls` or `-acme`.|                     |
-|`-tls-cert-file string` |Path to the TLS certificate file.                                                         |                     |
-|`-tls-key-file string`  |Path to the TLS private key file.                                                         |                     |
-|`-tls-port int`         |The port for the secure TLS (HTTPS) listener.                                             |`443`                |
-|`-upstream-url string`  |The URL of the upstream server to mirror/proxy.                                           |`https://ziglang.org`|
-|`-version`              |Print version information and exit.                                                       |                     |
+|Flag                    |Description                                                                                   |Default value        |
+|:-----------------------|:---------------------------------------------------------------------------------------------|:--------------------|
+|`-acme`                 |Obtain TLS certificates using the ACME challenge.                                             |                     |
+|`-acme-accept-tos`      |Accept the ACME provider's Terms of Service.                                                  |                     |
+|`-acme-cache string`    |Directory for storing obtained certificates.                                                  |                     |
+|`-acme-directory string`|ACME directory URL.                                                                           |`https://acme-v02.api.letsencrypt.org/directory`|
+|`-acme-email string`    |Email address for ACME registration and recovery notices.                                     |                     |
+|`-acme-host string`     |The hostname (domain name) for which to obtain the ACME certificate.                          |                     |
+|`-cache-dir string`     |Path to the directory where downloaded content will be cached.                                |`./`                 |
+|`-enable-tls`           |Enable the TLS (HTTPS) server. Requires `-tls-cert-file` and `-tls-key-file`.                 |                     |
+|`-http-port int`        |The port for the plain HTTP listener.                                                         |`80`                 |
+|`-listen-address string`|The IP address to listen on. If empty, listens on all available interfaces.                   |                     |
+|`-redirect-to-https`    |Enable automatic redirection of HTTP requests to HTTPS. Requires `-enable-tls` or `-acme`.    |                     |
+|`-tls-cert-file string` |Path to the TLS certificate file.                                                             |                     |
+|`-tls-key-file string`  |Path to the TLS private key file.                                                             |                     |
+|`-tls-port int`         |The port for the secure TLS (HTTPS) listener.                                                 |`443`                |
+|`-upstream-url string`  |The URL of the upstream server to mirror/proxy.                                               |`https://ziglang.org`|
+|`-version`              |Print version information and exit.                                                           |                     |
+|`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
+|`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
 
 ## Deployment
 ### Using systemd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,9 +76,10 @@ func run() error {
 		} else {
 			mux.Handle("/", http.FileServer(http.Dir(cfg.IndexPage)))
 		}
+
+		mux.Handle("/assets/", http.FileServer(http.FS(assets)))
 	}
 
-	mux.Handle("/assets/", http.FileServer(http.FS(assets)))
 	mux.HandleFunc("/{file}", cache.Handler())
 	mux.HandleFunc("/zig/{file}", cache.Handler())
 	mux.HandleFunc("/builds/{file}", cache.Handler())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,7 +70,14 @@ func run() error {
 	mux := http.NewServeMux()
 	cache := handlers.NewCache(cfg.UpstreamURL, cfg.CacheDir)
 
-	mux.HandleFunc("/", handlers.RootHandler(tmpl))
+	if cfg.ShowIndexPage {
+		if cfg.IndexPage == "" {
+			mux.HandleFunc("/", handlers.RootHandler(tmpl))
+		} else {
+			mux.Handle("/", http.FileServer(http.Dir(cfg.IndexPage)))
+		}
+	}
+
 	mux.Handle("/assets/", http.FileServer(http.FS(assets)))
 	mux.HandleFunc("/{file}", cache.Handler())
 	mux.HandleFunc("/zig/{file}", cache.Handler())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	EnableTLS       bool
 	RedirectToHTTPS bool
 	ShowVersion     bool
+	ShowIndexPage   bool
+	IndexPage       string
 
 	ACME          bool
 	ACMEDirectory string
@@ -53,6 +55,8 @@ func ParseConfig() (Config, error) {
 	flag.StringVar(&c.tlsKeyFile, "tls-key-file", "", "Path to the TLS private key file.")
 	flag.BoolVar(&c.RedirectToHTTPS, "redirect-to-https", false, "Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls or -acme.")
 	flag.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
+	flag.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
+	flag.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
 
 	flag.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
 	flag.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")


### PR DESCRIPTION
## Description
Added a feature - customizable index page.
Serve a custom landing page or static directory at the root, with option to completely disable the default index.

|Flag                    |Description                                                                                   |Default value        |
|:-----------------------|:---------------------------------------------------------------------------------------------|:--------------------|
|`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
|`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |