### PR TITLE
Periodically remove cached dev builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - Added `-show-index-page` and `-index-page` flags to allow users to customize or disable the root index page.
+- Added `-clear-builds-interval` flag to automatically clean up stale Zig development artifacts from the cache.
+- Added background task to periodically remove cached dev builds based on the configured interval.
+- Added a new `zig` internal package to centralize artifact validation and parsing logic.
 
 ### Security
 - Updated `golang.org/x/crypto` library (`v0.41.0` -> `v0.49.0`) (thanks dependabot for that)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Run `./go-mirror-zig -help` to see all available options.
 |`-version`              |Print version information and exit.                                                           |                     |
 |`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
 |`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
+|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`86400`              |
 
 ## Deployment
 ### Using systemd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,12 +11,14 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/savalione/go-mirror-zig/handlers"
 	"github.com/savalione/go-mirror-zig/internal/config"
+	"github.com/savalione/go-mirror-zig/internal/zig"
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -64,6 +66,44 @@ func run() error {
 			print("unknown")
 		}
 		os.Exit(0)
+	}
+
+	// A background task to clear zig build artifacts
+	if cfg.ClearBuilds != 0 {
+		clearBuildsTicker := time.NewTicker(time.Duration(cfg.ClearBuilds) * time.Second)
+		defer clearBuildsTicker.Stop()
+
+		go func() {
+			for {
+				select {
+				case <-shutdownCtx.Done():
+					return
+				case <-clearBuildsTicker.C:
+					buildPath := filepath.Join(cfg.CacheDir, "/builds/")
+					buildFiles, err := os.ReadDir(buildPath)
+					if err != nil {
+						slog.Error("failed to scan cache directory for cleanup", "path", buildPath, "error", err)
+						continue
+					}
+
+					for _, file := range buildFiles {
+						// Skip empty directories
+						if file.IsDir() {
+							continue
+						}
+
+						if zig.IsZigArtifact(file.Name()) {
+							filePath := filepath.Join(buildPath, file.Name())
+							if err := os.Remove(filePath); err != nil {
+								slog.Error("failed to remove a stale zig artifact", "path", filePath, "error", err)
+							} else {
+								slog.Info("a stale zig artifact removed", "path", filePath)
+							}
+						}
+					}
+				}
+			}
+		}()
 	}
 
 	// HTTP and HTTPS Handler setup

--- a/handlers/cache.go
+++ b/handlers/cache.go
@@ -9,13 +9,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
-)
 
-var filenameRegex = regexp.MustCompile(`^zig(?:|-bootstrap|-[a-zA-Z0-9_]+-[a-zA-Z0-9_]+)-(\d+\.\d+\.\d+(?:-dev\.\d+\+[0-9a-f]+)?)\.(?:tar\.xz|zip)(?:\.minisig)?$`)
+	"github.com/savalione/go-mirror-zig/internal/zig"
+)
 
 // Cache holds the dependencies for the cache handler, making it more testable and organized.
 type Cache struct {
@@ -53,19 +52,20 @@ func (c *Cache) Handler() http.HandlerFunc {
 		)
 
 		// Validate filename.
-		matches := filenameRegex.FindStringSubmatch(filename)
-		if len(matches) < 2 {
+		if !zig.IsZigArtifact(filename) {
 			logger.Warn("invalid filename format")
 			http.Error(w, "Invalid filename format", http.StatusBadRequest)
 			return
 		}
 
+		zigSubmatches := zig.ArtifactSubmatches(filename)
+
 		// Full path to the file.
 		var fileFullPath string
-		if strings.Contains(matches[1], "-dev") {
+		if strings.Contains(zigSubmatches[1], "-dev") {
 			fileFullPath = filepath.Join(c.cacheDir, "builds", filename)
 		} else {
-			fileFullPath = filepath.Join(c.cacheDir, "download", matches[1], filename)
+			fileFullPath = filepath.Join(c.cacheDir, "download", zigSubmatches[1], filename)
 		}
 
 		if fileExists(fileFullPath) {
@@ -94,7 +94,7 @@ func (c *Cache) Handler() http.HandlerFunc {
 
 		// Fetch from upstream
 		logger.Info("file not in cache, starting download")
-		if err := c.fetchAndCacheFile(r.Context(), logger, filename, matches[1]); err != nil {
+		if err := c.fetchAndCacheFile(r.Context(), logger, filename, zigSubmatches[1]); err != nil {
 			if errors.Is(err, errUpstreamNotFound) {
 				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			} else if errors.Is(err, errUpstreamUnavailable) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ShowVersion     bool
 	ShowIndexPage   bool
 	IndexPage       string
+	ClearBuilds     int
 
 	ACME          bool
 	ACMEDirectory string
@@ -57,6 +58,7 @@ func ParseConfig() (Config, error) {
 	flag.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
 	flag.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
 	flag.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
+	flag.IntVar(&c.ClearBuilds, "clear-builds-interval", 86400, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
 
 	flag.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
 	flag.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")
@@ -111,6 +113,10 @@ func ParseConfig() (Config, error) {
 		if c.EnableTLS {
 			return c, errors.New("manual TLS settings (-tls-cert-file, -tls-key-file) cannot be used with ACME")
 		}
+	}
+
+	if c.ClearBuilds < 0 {
+		return c, errors.New("the -clear-builds-interval flag can't be negative")
 	}
 
 	return c, nil

--- a/internal/zig/zig.go
+++ b/internal/zig/zig.go
@@ -1,0 +1,27 @@
+package zig
+
+import "regexp"
+
+// Matches standard Zig distribution filenames, capturing the version string.
+var filenameRegex = regexp.MustCompile(`^zig(?:|-bootstrap|-[a-zA-Z0-9_]+-[a-zA-Z0-9_]+)-(\d+\.\d+\.\d+(?:-dev\.\d+\+[0-9a-f]+)?)\.(?:tar\.xz|zip)(?:\.minisig)?$`)
+
+// Checks whether the provided string follow the official Zig artifact naming convention.
+// It returns true if the string matches the expected pattern, false otherwise.
+func IsZigArtifact(s string) bool {
+	if len(filenameRegex.FindStringSubmatch(s)) < 2 {
+		return false
+	}
+	return true
+}
+
+// Extracts the submatches from a Zig artifact filename.
+// Returns nil if the provided string does not follow the official Zig artifact naming convention.
+func ArtifactSubmatches(s string) []string {
+
+	matches := filenameRegex.FindStringSubmatch(s)
+	if len(matches) < 2 {
+		return nil
+	}
+
+	return matches
+}


### PR DESCRIPTION
## Description
Added background task to periodically remove cached dev builds based on the configured interval, so there is no issue like this:
> The problem was related to improper cleaning of old dev builds, which resulted in running out of disk space (~120GB builds per server :)).

See: https://github.com/ziglang/www.ziglang.org/pull/591

## Changes
- Added `-clear-builds-interval` flag to automatically clean up stale Zig development artifacts from the cache.
- Added background task to periodically remove cached dev builds based on the configured interval.
- Added a new `zig` internal package to centralize artifact validation and parsing logic.
