### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-03-14
 ### Added
 - Added `-show-index-page` and `-index-page` flags to allow users to customize or disable the root index page.
 - Added `-clear-builds-interval` flag to automatically clean up stale Zig development artifacts from the cache.


### PR DESCRIPTION
## [1.1.0] - 2026-03-14
### Added
- Added `-show-index-page` and `-index-page` flags to allow users to customize or disable the root index page.
- Added `-clear-builds-interval` flag to automatically clean up stale Zig development artifacts from the cache.
- Added background task to periodically remove cached dev builds based on the configured interval.
- Added a new `zig` internal package to centralize artifact validation and parsing logic.
- Added server version and system architecture information to the index page.

### Security
- Updated `golang.org/x/crypto` library (`v0.41.0` -> `v0.49.0`) (thanks dependabot for that)

### Fixed
- Fixed minimal required Go version in the README.md.

### Changed
- Changed project's Go version (`1.25.0` -> `1.26.1`)