### PR TITLE
Version 1.2.6 (intelligent cleanup, tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added tests for the index handler
+- Added tests for the middleware handler
+- Added tests for the redirect handler
+- Added tests for the configuration parser
+- Added tests for the zig internal functions (`internal/zig/zig.go`)
+
+### Fixed
+- Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
+- Added a message indicating that the ToS are not accepted
+
+### Changed
+- Increased the interval in seconds to clean up cached dev builds (from 1 day to 4 days)
+- The HTTP to HTTPS redirect now omits the `443` port if it's not required
+
 ## [1.1.0] - 2026-03-14
 ### Added
 - Added `-show-index-page` and `-index-page` flags to allow users to customize or disable the root index page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added tests for the redirect handler
 - Added tests for the configuration parser
 - Added tests for the zig internal functions (`internal/zig/zig.go`)
+- Added a new deployment subsection to the readme (using nginx as a proxy)
 
 ### Fixed
 - Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
 - Added a message indicating that the ToS are not accepted
 - Removed version string from `internal/config/config.go` (it wasn't used)
+- Fixed readme information about the interval in seconds to clean up cached dev builds
 
 ### Changed
 - Increased the interval in seconds to clean up cached dev builds (from 1 day to 4 days)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added tests for the configuration parser
 - Added tests for the zig internal functions (`internal/zig/zig.go`)
 - Added a new deployment subsection to the readme (using nginx as a proxy)
+- Added Zig Programming Language link to the top section of readme
+- Added functionality to fetch and process the `index.json` (Zig releases in JSON format)
+- Added function to calculate the total size of all Zig artifacts that can be downloaded from the official servers and cached
 
 ### Fixed
 - Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
@@ -20,8 +23,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed readme information about the interval in seconds to clean up cached dev builds
 
 ### Changed
-- Increased the interval in seconds to clean up cached dev builds (from 1 day to 4 days)
+- Increased the interval in seconds to clean up cached dev builds (from 1 day to 2 days)
+- Reduced the interval in seconds to clean up cached dev builds (from 2 days to 1 day)
+    - Reverting the previous change.
+        Sometimes it takes ~4 days to release a new artifact, sometimes ~2 hours.
+        Instead of relying simply on periodic cache cleanup, a better approach will be implemented.
 - The HTTP to HTTPS redirect now omits the `443` port if it's not required
+- Replaced links to the Zig main repository (GitHub -> Codeberg)
+- Updated table driven tests that test regexp (`internal/zig/zig_test.go`)
+- Tests for the configuration parser now can test the parser itself
 
 ## [1.1.0] - 2026-03-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added Zig Programming Language link to the top section of readme
 - Added functionality to fetch and process the `index.json` (Zig releases in JSON format)
 - Added function to calculate the total size of all Zig artifacts that can be downloaded from the official servers and cached
+- Added `-estimate-cache-size` flag to display upstream artifact statistics
 
 ### Fixed
 - Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.6] - 2026-05-19
 ### Added
 - Added test suites for the index, middleware, redirect, and configuration parser handlers.
 - Added unit tests for Zig internal logic in `internal/zig/zig.go`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
 - Added a message indicating that the ToS are not accepted
+- Removed version string from `internal/config/config.go` (it wasn't used)
 
 ### Changed
 - Increased the interval in seconds to clean up cached dev builds (from 1 day to 4 days)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,43 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Added
-- Added tests for the index handler
-- Added tests for the middleware handler
-- Added tests for the redirect handler
-- Added tests for the configuration parser
-- Added tests for the zig internal functions (`internal/zig/zig.go`)
-- Added a new deployment subsection to the readme (using nginx as a proxy)
-- Added Zig Programming Language link to the top section of readme
-- Added functionality to fetch and process the `index.json` (Zig releases in JSON format)
-- Added function to calculate the total size of all Zig artifacts that can be downloaded from the official servers and cached
-- Added `-estimate-cache-size` flag to display upstream artifact statistics
+- Added test suites for the index, middleware, redirect, and configuration parser handlers.
+- Added unit tests for Zig internal logic in `internal/zig/zig.go`.
+- Added a deployment subsection to the README for using Nginx as a reverse proxy.
+- Added a direct link to the Zig Programming Language website in the README header.
+- Added functionality to fetch and parse the upstream `index.json` for release processing.
+- Added a function to calculate the total cacheable size of all upstream Zig artifacts.
+- Added the `-show-possible-size` flag to display upstream artifact statistics (total size, release counts, and median sizes) before exiting.
+- Added intelligent periodic cache cleanup that cross-references the local cache with the upstream `index.json` to preserve active `master` builds while removing stale ones.
+- Added aggregate logging for the cleanup task, reporting the total number of files removed and space reclaimed (in bytes).
+- Added new targets to the build script:
+    - `linux/riscv64`
+    - `linux/386`
+    - `linux/ppc64le`
+    - `linux/loong64`
+    - `windows/arm64`
+    - `freebsd/amd64`
+    - `freebsd/arm64`
+    - `netbsd/amd64`
+    - `netbsd/arm64`
+    - `openbsd/amd64`
+    - `openbsd/arm64`
+
 
 ### Fixed
-- Fixed weird behavior of temporary files (windows and unix handle them differently). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
-- Added a message indicating that the ToS are not accepted
-- Removed version string from `internal/config/config.go` (it wasn't used)
-- Fixed readme information about the interval in seconds to clean up cached dev builds
+- Fixed inconsistent behavior of temporary files across platforms (Windows vs. Linux file locking). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
+- Added a warning message when ACME Terms of Service are not explicitly accepted.
+- Removed an unused version string from the `config` package.
+- Corrected the documentation regarding the default interval for cleaning up cached dev builds.
+- Fixed grammar in the changelog.
 
 ### Changed
-- Increased the interval in seconds to clean up cached dev builds (from 1 day to 2 days)
-- Reduced the interval in seconds to clean up cached dev builds (from 2 days to 1 day)
-    - Reverting the previous change.
-        Sometimes it takes ~4 days to release a new artifact, sometimes ~2 hours.
-        Instead of relying simply on periodic cache cleanup, a better approach will be implemented.
+- Replaced GitHub links with Codeberg links for the official Zig main repository.
 - The HTTP to HTTPS redirect now omits the `443` port if it's not required
-- Replaced links to the Zig main repository (GitHub -> Codeberg)
-- Updated table driven tests that test regexp (`internal/zig/zig_test.go`)
-- Tests for the configuration parser now can test the parser itself
+- Reduced the interval in seconds to clean up cached dev builds (from 1 day to 2 hours), thanks to the intelligent periodic cache cleanup feature.
+- Updated table driven tests for artifact regex matching.
+- Improved the configuration parser tests.
+- Updated readme.
 
 ## [1.1.0] - 2026-03-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Run `./go-mirror-zig -help` to see all available options.
 |`-tls-port int`         |The port for the secure TLS (HTTPS) listener.                                                 |`443`                |
 |`-upstream-url string`  |The URL of the upstream server to mirror/proxy.                                               |`https://ziglang.org`|
 |`-version`              |Print version information and exit.                                                           |                     |
+|`-show-possible-size`   |Print estimation stats of all cacheable upstream artifacts (size, release counts) and exit.   |                     |
 |`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
 |`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
 |`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`86400`              |

--- a/README.md
+++ b/README.md
@@ -124,40 +124,91 @@ Run `./go-mirror-zig -help` to see all available options.
 |`-version`              |Print version information and exit.                                                           |                     |
 |`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
 |`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
-|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`86400`              |
+|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`345600`             |
 
 ## Deployment
-### Using systemd
-Here is an example service file for running the application with systemd.
+### Using systemd and nginx as a reverse proxy
+Here is an example service file for running the application with systemd and nginx as a reverse proxy.
+1. Create the service file:
+    ```sh
+    sudo nano /etc/systemd/system/go-mirror-zig.service
+    ```
+2. Add the following configuration, adjusting paths and flags as needed:
+    ```ini
+    [Unit]
+    Description=Go Mirror Zig Service
+    After=network.target
+
+    [Service]
+    User=zig-mirror
+    Group=zig-mirror
+    Type=simple
+    WorkingDirectory=/opt/zig-mirror
+    ExecStart=/go-mirror-zig -http-port=8888 -cache-dir=/zig-mirror
+    Restart=on-failure
+    RestartSec=5s
+
+    [Install]
+    WantedBy=multi-user.target
+    ```
+3. Create nginx virtual host
+    ```
+    server {
+        server_name zig.example.com;
+
+        listen 80;
+        listen [::]:80;
+
+        location / {
+            proxy_pass http://127.0.0.1:8888;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Protocol $scheme;
+            proxy_set_header X-Forwarded-Host $http_host;
+        }
+    }
+    ```
+4. Enable and start go-mirror-zig, reload nginx:
+    ```sh
+    sudo systemctl daemon-reload
+    sudo systemctl enable go-mirror-zig.service
+    sudo systemctl start go-mirror-zig.service
+    sudo systemctl reload nginx
+    ```
+
+### Using systemd and ACME challenge
+Here is an example service file for running the application with systemd and ACME challenge.
 
 1. Create the service file:
       ```sh
       sudo nano /etc/systemd/system/go-mirror-zig.service
       ```
 2. Add the following configuration, adjusting paths and flags as needed:
-      ```ini
-      [Unit]
-      Description=Go Mirror Zig Service
-      After=network.target
+    ```ini
+    [Unit]
+    Description=Go Mirror Zig Service
+    After=network.target
 
-      [Service]
-      User=zig-mirror
-      Group=zig-mirror
-      Type=simple
-      WorkingDirectory=/opt/zig-mirror
-      ExecStart=/go-mirror-zig -cache-dir=/zig-mirror -acme -acme-accept-tos -acme-host=zig.example.com -acme-email=admin@example.com -acme-cache=/var/lib/zig-mirror/acme -redirect-to-https
-      Restart=on-failure
-      RestartSec=5s
+    [Service]
+    User=zig-mirror
+    Group=zig-mirror
+    Type=simple
+    WorkingDirectory=/opt/zig-mirror
+    ExecStart=/go-mirror-zig -cache-dir=/zig-mirror -acme -acme-accept-tos -acme-host=zig.example.com -acme-email=admin@example.com -acme-cache=/var/lib/zig-mirror/acme -redirect-to-https
+    Restart=on-failure
+    RestartSec=5s
 
-      [Install]
-      WantedBy=multi-user.target
-      ```
+    [Install]
+    WantedBy=multi-user.target
+    ```
 3. Reload, enable, and start the service:
-      ```sh
-      sudo systemctl daemon-reload
-      sudo systemctl enable go-mirror-zig.service
-      sudo systemctl start go-mirror-zig.service
-      ```
+    ```sh
+    sudo systemctl daemon-reload
+    sudo systemctl enable go-mirror-zig.service
+    sudo systemctl start go-mirror-zig.service
+    ```
 
 ## Contributing
 Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Go Mirror Zig
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) [![Go Report Card](https://goreportcard.com/badge/github.com/savalione/go-mirror-zig)](https://goreportcard.com/report/github.com/savalione/go-mirror-zig) ![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg) ![GitHub last commit](https://img.shields.io/github/last-commit/savalione/go-mirror-zig) ![GitHub issues](https://img.shields.io/github/issues/savalione/go-mirror-zig)
 
-A self-hostable solution written in Go for creating a community mirror for the Zig programming language.
+A self-hostable solution written in Go for creating a community mirror for the Zig programming language ([Zig Programming Language](https://ziglang.org/)).
 This application is designed for communities, companies, or individuals looking to provide faster local access to Zig toolchains, reducing latency and bandwidth usage on the official servers.
 
 It is lightweight and distributed as a single binary.
@@ -124,7 +124,7 @@ Run `./go-mirror-zig -help` to see all available options.
 |`-version`              |Print version information and exit.                                                           |                     |
 |`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
 |`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
-|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`345600`             |
+|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`86400`              |
 
 ## Deployment
 ### Using systemd and nginx as a reverse proxy
@@ -227,5 +227,5 @@ Copyright (C) 2025 Savelii Pototskii (savalione.com)
 This project incorporates code from several third-party libraries and assets.
 We are grateful to their developers and maintainers.
 * [new.css](https://github.com/xz/new.css) - MIT License
-* [Official Zig Project Logo](https://github.com/ziglang/logo) - CC BY-SA 4.0
+* [Official Zig Project Logo](https://codeberg.org/ziglang/logo) - CC BY-SA 4.0
 * [The Inter font family](https://github.com/rsms/inter) - OFL-1.1 License

--- a/README.md
+++ b/README.md
@@ -7,85 +7,57 @@ This application is designed for communities, companies, or individuals looking 
 It is lightweight and distributed as a single binary.
 
 ## Features
-* Efficient caching: Downloads files from an upstream server once and serves them from a local cache for all subsequent requests.
-* Automatic TLS: Full support for ACME (Let's Encrypt) to automatically obtain and renew TLS certificates.
-* Secure by default: Supports HTTPS and automatic redirection from HTTP to HTTPS.
-* Standalone binary: Compiles to a single, dependency-free binary for easy deployment.
-* Configurable: All settings are manageable via command-line flags, including ports, cache directories, and upstream URL.
-* Path correctness: Caches files using the official Zig directory layout (`/download/<version>/` and `/builds/`).
+* Artifact caching: Local storage of upstream content uses the official Zig directory structure.
+* Integrated security: ACME (Let's Encrypt) support and automatic HTTP to HTTPS redirection.
+* Standalone binary: Single, dependency-free binary with no external runtime requirements.
+* CLI configuration: Parameter control via commandline flags for ports, paths, and upstream settings.
+* Automated maintenance: Periodic removal of stale development builds synchronized with the upstream index.
 * Customizable index page: Serve a custom landing page or static directory at the root, with option to completely disable the default index.
 
-## Getting Started
-### From a Precompiled Binary
+## Getting started
+### From a precompiled Binary
 This is the recommended method for most users.
-1.  Navigate to the [latest release page](https://github.com/savalione/go-mirror-zig/releases/latest).
-2.  Download the archive for your operating system and architecture (e.g., `go-mirror-zig-v1.0.0-linux-amd64.tar.gz`).
-3.  Extract the archive.
-    ```sh
-    tar -xvzf go-mirror-zig-v1.0.0-linux-amd64.tar.gz
-    ```
-4.  Run the application. You can verify it's working by checking the version or help output.
-    ```sh
-    ./go-mirror-zig --version
-    ```
+
+Navigate to the [latest release page](https://github.com/savalione/go-mirror-zig/releases/latest).
+
+Download the archive for your operating system and architecture (e.g., `go-mirror-zig-v1.0.0-linux-amd64.tar.gz`).
+Extract the archive.
+```sh
+tar -xvzf go-mirror-zig-v1.0.0-linux-amd64.tar.gz
+```
+
+Run the application. You can verify it's working by checking the version or help output.
+```sh
+./go-mirror-zig --version
+```
 
 ### From source
 Ensure you have a recent version of Go installed.
-1.  Clone the repository:
-      ```sh
-      git clone https://github.com/savalione/go-mirror-zig.git
-      ```
-2.  Navigate to the project directory:
-      ```sh
-      cd go-mirror-zig
-      ```
-3.  Build the project:
-      ```sh
-      go build -o go-mirror-zig ./cmd/main.go
-      ```
+
+Clone the repository:
+```sh
+git clone https://github.com/savalione/go-mirror-zig.git
+```
+
+Navigate to the project directory:
+```sh
+cd go-mirror-zig
+```
+
+Build the project:
+```sh
+go build -o go-mirror-zig ./cmd/main.go
+```
 
 ## Examples
-### With Nginx
-For example, you have the following setup:
-* A headless (CLI access only) Ubuntu server.
-* Nginx as a caching (and ACME challenge) proxy.
-
-In this setup the ports `80` (HTTP) and `443` (HTTPS) are already occupied by the caching proxy.
-
-First, you need to decide where the cache will be stored.
-For this example, we'll assume you want to store it in the `/zig-mirror` directory, which you have already created.
-
-You can run the application with the following flags:
+### Running behind a reverse proxy (e.g., nginx)
+If you already have nginx or Apache on ports 80/443, run the mirror on a high port (like 8080) and let the proxy handle TLS.
+See the [deployment](#deployment) section for the nginx configuration.
 ```sh
-go-mirror-zig -http-port 8080 -cache-dir="/zig-mirror"
+./go-mirror-zig -http-port 8080 -cache-dir="/zig-mirror"
 ```
 
-Then you need to create a Nginx configuration for your mirror:
-```
-# zig.example.com
-server {
-    listen 80;
-    server_name zig.example.com;
-
-    location ~/.well-known {
-        allow all;
-    }
-
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Protocol $scheme;
-        proxy_set_header X-Forwarded-Host $http_host;
-    }
-}
-```
-
-In the end you may issue a TLS certificate using certbot or manually set up certificates.
-
-### Standalone
+### Standalone with automatic TLS (ACME)
 For example you have a server without caching proxy.
 In that case you can set up the caching mirror with automatic ACME support.
 
@@ -97,7 +69,7 @@ After that you need to decide:
 
 Then you can run the application with the following flags:
 ```sh
-go-mirror-zig -acme -acme-accept-tos -acme-cache /secure-location -acme-email user@example.com -acme-host example.com -cache-dir /zig-mirror -redirect-to-https
+go-mirror-zig -acme -acme-accept-tos -acme-cache /secure-location -acme-email someone@example.com -acme-host example.com -cache-dir /zig-mirror -redirect-to-https
 ```
 
 ## Configuration
@@ -125,91 +97,118 @@ Run `./go-mirror-zig -help` to see all available options.
 |`-show-possible-size`   |Print estimation stats of all cacheable upstream artifacts (size, release counts) and exit.   |                     |
 |`-show-index-page bool` |Whether to serve a custom index page at the root (/). Set to false to disable.                |`true`               |
 |`-index-page string`    |Path to a directory containing static files for the index. If empty, the default page is used.|built-in index page  |
-|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`86400`              |
+|`-clear-builds-interval`|Interval in seconds to clean up cached dev builds. Set to 0 to disable.                       |`7200`               |
 
 ## Deployment
 ### Using systemd and nginx as a reverse proxy
-Here is an example service file for running the application with systemd and nginx as a reverse proxy.
-1. Create the service file:
-    ```sh
-    sudo nano /etc/systemd/system/go-mirror-zig.service
-    ```
-2. Add the following configuration, adjusting paths and flags as needed:
-    ```ini
-    [Unit]
-    Description=Go Mirror Zig Service
-    After=network.target
+For example, you have the following setup:
+* A headless (CLI access only) Ubuntu server.
+* nginx as a caching (and ACME challenge) proxy.
 
-    [Service]
-    User=zig-mirror
-    Group=zig-mirror
-    Type=simple
-    WorkingDirectory=/opt/zig-mirror
-    ExecStart=/go-mirror-zig -http-port=8888 -cache-dir=/zig-mirror
-    Restart=on-failure
-    RestartSec=5s
+In this setup the ports `80` (HTTP) and `443` (HTTPS) are already occupied by the caching proxy.
 
-    [Install]
-    WantedBy=multi-user.target
-    ```
-3. Create nginx virtual host
-    ```
-    server {
-        server_name zig.example.com;
+First, you need to decide where the cache will be stored.
+For this example, we'll assume you want to store it in the `/zig-mirror` directory, which you have already created.
 
-        listen 80;
-        listen [::]:80;
+Create a service file:
+```sh
+sudo nano /etc/systemd/system/go-mirror-zig.service
+```
 
-        location / {
-            proxy_pass http://127.0.0.1:8888;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Protocol $scheme;
-            proxy_set_header X-Forwarded-Host $http_host;
-        }
+Add the following configuration, adjusting paths and flags as needed:
+```ini
+[Unit]
+Description=Go Mirror Zig Service
+After=network.target
+
+[Service]
+User=zig-mirror
+Group=zig-mirror
+Type=simple
+WorkingDirectory=/opt/zig-mirror
+ExecStart=/go-mirror-zig -http-port=8888 -cache-dir=/zig-mirror
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then you need to create a nginx configuration for your mirror:
+```
+# zig.example.com
+server {
+    listen 80;
+    server_name zig.example.com;
+
+    location ~/.well-known {
+        allow all;
     }
-    ```
-4. Enable and start go-mirror-zig, reload nginx:
-    ```sh
-    sudo systemctl daemon-reload
-    sudo systemctl enable go-mirror-zig.service
-    sudo systemctl start go-mirror-zig.service
-    sudo systemctl reload nginx
-    ```
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
+}
+```
+
+Enable and start go-mirror-zig, reload nginx:
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable go-mirror-zig.service
+sudo systemctl start go-mirror-zig.service
+sudo systemctl reload nginx
+```
+
+In the end you may issue a TLS certificate using Certbot/acme.sh or manually set up certificates.
 
 ### Using systemd and ACME challenge
 Here is an example service file for running the application with systemd and ACME challenge.
 
-1. Create the service file:
-      ```sh
-      sudo nano /etc/systemd/system/go-mirror-zig.service
-      ```
-2. Add the following configuration, adjusting paths and flags as needed:
-    ```ini
-    [Unit]
-    Description=Go Mirror Zig Service
-    After=network.target
+Create the service file:
+```sh
+sudo nano /etc/systemd/system/go-mirror-zig.service
+```
 
-    [Service]
-    User=zig-mirror
-    Group=zig-mirror
-    Type=simple
-    WorkingDirectory=/opt/zig-mirror
-    ExecStart=/go-mirror-zig -cache-dir=/zig-mirror -acme -acme-accept-tos -acme-host=zig.example.com -acme-email=admin@example.com -acme-cache=/var/lib/zig-mirror/acme -redirect-to-https
-    Restart=on-failure
-    RestartSec=5s
+Add the following configuration, adjusting paths and flags as needed:
+```ini
+[Unit]
+Description=Go Mirror Zig Service
+After=network.target
 
-    [Install]
-    WantedBy=multi-user.target
-    ```
-3. Reload, enable, and start the service:
-    ```sh
-    sudo systemctl daemon-reload
-    sudo systemctl enable go-mirror-zig.service
-    sudo systemctl start go-mirror-zig.service
-    ```
+[Service]
+User=zig-mirror
+Group=zig-mirror
+Type=simple
+WorkingDirectory=/opt/zig-mirror
+ExecStart=/go-mirror-zig -cache-dir=/zig-mirror -acme -acme-accept-tos -acme-host=zig.example.com -acme-email=someone@example.com -acme-cache=/var/lib/zig-mirror/acme -redirect-to-https
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload, enable, and start the service:
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable go-mirror-zig.service
+sudo systemctl start go-mirror-zig.service
+```
+
+### Standalone without TLS and systemd
+You need to decide where the cache will be stored.
+In this example, the cache will be stored in `/zig-mirror`.
+
+Run the application with the following flags:
+```sh
+go-mirror-zig -cache-dir="/zig-mirror"
+```
 
 ## Contributing
 Contributions are welcome!
@@ -218,13 +217,13 @@ We value a healthy and collaborative community.
 Please read our [Contributing Guidelines](CONTRIBUTING.md) to get started.
 All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-## Licenses and Acknowledgements
+## Licenses and acknowledgements
 This project is licensed under [The GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).
 See the [LICENSE](LICENSE) file for the full license text.
 
-Copyright (C) 2025 Savelii Pototskii (savalione.com)
+Copyright (C) 2025-2026 Savelii Pototskii (savalione.com)
 
-### Third-Party Libraries and Assets
+### Third-party libraries and assets
 This project incorporates code from several third-party libraries and assets.
 We are grateful to their developers and maintainers.
 * [new.css](https://github.com/xz/new.css) - MIT License

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -11,11 +11,29 @@ mkdir -p release
 
 # Target platforms.
 PLATFORMS=(
+    # Linux
     "linux/amd64"
     "linux/arm64"
+    "linux/riscv64"
+    "linux/386"
+    "linux/ppc64le"
+    "linux/loong64"
+
+    # Windows
     "windows/amd64"
+    "windows/arm64"
+
+    # macOS
     "darwin/amd64"
     "darwin/arm64"
+
+    # BSD
+    "freebsd/amd64"
+    "freebsd/arm64"
+    "netbsd/amd64"
+    "netbsd/arm64"
+    "openbsd/amd64"
+    "openbsd/arm64"
 )
 
 echo "Building release artifacts for version ${VERSION}..."

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -65,6 +67,13 @@ func run() error {
 			print(version)
 		} else {
 			print("unknown")
+		}
+		os.Exit(0)
+	}
+
+	if cfg.ShowPossibleSize {
+		if err := showPossibleSize(shutdownCtx, cfg); err != nil {
+			return err
 		}
 		os.Exit(0)
 	}
@@ -241,4 +250,86 @@ func startServer(ctx context.Context, wg *sync.WaitGroup, srv *http.Server) {
 	if err := srv.Shutdown(shutdownTimeoutCtx); err != nil {
 		slog.Error(fmt.Sprintf("failed to shut down %s server gracefully", serverType), "addr", srv.Addr, "error", err)
 	}
+}
+
+func showPossibleSize(ctx context.Context, cfg config.Config) error {
+	zr, err := zig.FetchAllReleases(ctx, cfg.UpstreamURL+"/download/index.json")
+	if err != nil {
+		return fmt.Errorf("error fetching the index.json with all Zig releases: %w", err)
+	}
+
+	// Information about Zig releases
+	type CacheStats struct {
+		TotalReleases     int
+		TotalArtifacts    int
+		TotalSizeBytes    int64
+		DevSizeBytes      int64
+		MedianReleaseSize int64
+	}
+
+	// Size and release metrics from the index.json
+	calculateStats := func(zr zig.ZigReleases) CacheStats {
+		var stats CacheStats
+		var releaseSizes []int64
+
+		stats.TotalReleases = len(zr)
+
+		for version, release := range zr {
+			var currentReleaseSize int64
+			for _, artifact := range release.Platforms {
+				sizeBytes, err := strconv.ParseInt(artifact.Size, 10, 64)
+				if err != nil {
+					continue
+				}
+				currentReleaseSize += sizeBytes
+				stats.TotalArtifacts++
+			}
+
+			stats.TotalSizeBytes += currentReleaseSize
+			releaseSizes = append(releaseSizes, currentReleaseSize)
+
+			if version == "master" {
+				stats.DevSizeBytes += currentReleaseSize
+			}
+		}
+
+		// Median size of a release
+		if len(releaseSizes) > 0 {
+			sort.Slice(releaseSizes, func(i, j int) bool { return releaseSizes[i] < releaseSizes[j] })
+			mid := len(releaseSizes) / 2
+
+			if len(releaseSizes)%2 == 0 {
+				stats.MedianReleaseSize = (releaseSizes[mid-1] + releaseSizes[mid]) / 2
+			} else {
+				stats.MedianReleaseSize = releaseSizes[mid]
+			}
+		}
+
+		return stats
+	}
+
+	formatBytes := func(b int64) string {
+		const unit = 1024
+		if b < unit {
+			return fmt.Sprintf("%d B", b)
+		}
+		div, exp := int64(unit), 0
+		for n := b / unit; n >= unit; n /= unit {
+			div *= unit
+			exp++
+		}
+		return fmt.Sprintf("%.2f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+	}
+
+	stats := calculateStats(zr)
+
+	fmt.Println("Zig artifacts cache estimation")
+	fmt.Printf("Upstream URL:          %s\n", cfg.UpstreamURL+"/download/index.json")
+	fmt.Printf("Total releases:        %d\n", stats.TotalReleases)
+	fmt.Printf("Total artifacts:       %d\n", stats.TotalArtifacts)
+	fmt.Printf("Total possible size:   %s (%d bytes)\n", formatBytes(stats.TotalSizeBytes), stats.TotalSizeBytes)
+	fmt.Printf("Size of master branch: %s\n", formatBytes(stats.DevSizeBytes))
+	fmt.Printf("Median release size:   %s\n", formatBytes(stats.MedianReleaseSize))
+
+	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"embed"
 	"errors"
+	"flag"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -54,7 +55,7 @@ func run() error {
 		return fmt.Errorf("error parsing templates: %w", err)
 	}
 
-	cfg, err := config.ParseConfig()
+	cfg, err := config.ParseConfig(os.Args[1:], flag.ExitOnError)
 	if err != nil {
 		return fmt.Errorf("error parsing configuration: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -89,27 +90,68 @@ func run() error {
 				case <-shutdownCtx.Done():
 					return
 				case <-clearBuildsTicker.C:
+					// Attempt to fetch index.json
+					ctx, cancel := context.WithTimeout(shutdownCtx, 30*time.Second)
+					zr, err := zig.FetchAllReleases(ctx, cfg.UpstreamURL+"/download/index.json")
+					cancel()
+
+					activeMasterBuilds := make(map[string]bool)
+					fetchSuccess := err == nil
+
+					if fetchSuccess {
+						if master, ok := zr["master"]; ok {
+							for _, art := range master.Platforms {
+								filename := path.Base(art.Tarball)
+								activeMasterBuilds[filename] = true
+							}
+						}
+					} else {
+						slog.Warn("failed to fetch index.json for cleanup, falling back to clearing all dev builds", "error", err)
+					}
+
 					buildPath := filepath.Join(cfg.CacheDir, "/builds/")
 					buildFiles, err := os.ReadDir(buildPath)
 					if err != nil {
-						slog.Error("failed to scan cache directory for cleanup", "path", buildPath, "error", err)
+						// For some reason the directory hasn't been created yet
+						if !os.IsNotExist(err) {
+							slog.Error("failed to scan cache directory for cleanup", "path", buildPath, "error", err)
+						}
+
 						continue
 					}
 
+					var removedCount int
+					var removedBytes int64
+
 					for _, file := range buildFiles {
-						// Skip empty directories
-						if file.IsDir() {
+						// Skip empty directories and everything but artifacts
+						if file.IsDir() || !zig.IsZigArtifact(file.Name()) {
 							continue
 						}
 
-						if zig.IsZigArtifact(file.Name()) {
-							filePath := filepath.Join(buildPath, file.Name())
-							if err := os.Remove(filePath); err != nil {
-								slog.Error("failed to remove a stale zig artifact", "path", filePath, "error", err)
-							} else {
-								slog.Info("a stale zig artifact removed", "path", filePath)
-							}
+						// Current dev build
+						if fetchSuccess && activeMasterBuilds[file.Name()] {
+							continue
 						}
+
+						filePath := filepath.Join(buildPath, file.Name())
+
+						// For stats
+						var fileSize int64
+						if info, err := file.Info(); err == nil {
+							fileSize = info.Size()
+						}
+
+						if err := os.Remove(filePath); err != nil {
+							slog.Error("failed to remove a stale zig artifact", "path", filePath, "error", err)
+						} else {
+							removedCount++
+							removedBytes += fileSize
+						}
+					}
+
+					if removedCount > 0 {
+						slog.Info("stale zig builds cleanup completed", "removed_count", removedCount, "reclaimed_space", removedBytes)
 					}
 				}
 			}

--- a/cmd/templates/index.html
+++ b/cmd/templates/index.html
@@ -24,7 +24,7 @@
         <p>This mirror is powered by <a href="https://github.com/savalione/go-mirror-zig/">go-mirror-zig</a>, a custom, open-source server implementation written in Go.</p>
 
         <h2>Support and Issue Reporting</h2>
-        <p>If you encounter any issues with this mirror, such as slow downloads or failed requests, please report them to the mirror's maintainer. The maintainer's contact information is available at <a href="https://github.com/ziglang/www.ziglang.org/blob/main/assets/community-mirrors.ziggy">github.com/ziglang/www.ziglang.org/assets/community-mirrors.ziggy</a></p>
+        <p>If you encounter any issues with this mirror, such as slow downloads or failed requests, please report them to the mirror's maintainer. The maintainer's contact information is available at <a href="https://codeberg.org/ziglang/ziglang.org/src/branch/main/assets/community-mirrors.ziggy">codeberg.org/ziglang/ziglang.org/src/branch/main/assets/community-mirrors.ziggy</a></p>
 
         <p>If you encounter any odd behavior related to the caching server software, such as incorrect checksums, wrong status codes, or other unexpected behavior, please report them by opening an issue on the project's GitHub repository: <a href="https://github.com/savalione/go-mirror-zig/issues">github.com/savalione/go-mirror-zig/issues</a></p>
 

--- a/handlers/cache.go
+++ b/handlers/cache.go
@@ -164,17 +164,26 @@ func (c *Cache) fetchAndCacheFile(ctx context.Context, logger *slog.Logger, file
 		logger.Error("failed to create temporary file", "error", err)
 		return err
 	}
-	defer func() {
-		// tmpFile.Close()
-		os.Remove(tmpFile.Name())
-	}()
 
 	// Stream the download to the temp file.
 	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		if err := tmpFile.Close(); err != nil {
+			logger.Error("failed to close the temporary file", "temp_file", tmpFile.Name(), "error", err)
+		}
+
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			logger.Error("failed to remove the temporary file", "temp_file", tmpFile.Name(), "error", err)
+		}
+
 		logger.Error("failed to write to temporary file", "temp_file", tmpFile.Name(), "error", err)
 		return err
 	}
-	tmpFile.Close()
+
+	// See: https://pkg.go.dev/os#example-CreateTemp-Suffix
+	// Also: On Linux it is allowed to delete an opened file, while on Windows it is not allowed
+	if err := tmpFile.Close(); err != nil {
+		logger.Error("failed to close the temporary file", "temp_file", tmpFile.Name(), "error", err)
+	}
 
 	// Create destination directory for the file.
 	if err := os.MkdirAll(pathDestination, 0775); err != nil {
@@ -185,6 +194,10 @@ func (c *Cache) fetchAndCacheFile(ctx context.Context, logger *slog.Logger, file
 	// Atomically move the file to its final destination.
 	fileDestination := filepath.Join(pathDestination, filename)
 	if err := os.Rename(tmpFile.Name(), fileDestination); err != nil {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			logger.Error("failed to remove the temporary file", "temp_file", tmpFile.Name(), "error", err)
+		}
+
 		logger.Error("failed to rename temporary file", "from", tmpFile.Name(), "to", fileDestination, "error", err)
 		return err
 	}

--- a/handlers/index_test.go
+++ b/handlers/index_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRootHandler(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		uri            string
+		version        string
+		expectedStatus int
+		expectedBody   string
+		template       *template.Template
+	}{
+		{
+			name:           "Template and version check",
+			uri:            "/",
+			version:        "1.2.3",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "<b>version 1.2.3</b>",
+			template:       template.Must(template.New("index.html").Parse("<b>version {{ .Version }}</b>")),
+		},
+		{
+			name:           "404 on wrong path",
+			uri:            "/should-not-work/",
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "404 page not found",
+			template:       template.Must(template.New("index.html").Parse("")),
+		},
+		{
+			name:           "Empty version defaults to unknown",
+			uri:            "/",
+			version:        "",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "<b>version unknown</b>",
+			template:       template.Must(template.New("index.html").Parse("<b>version {{ .Version }}</b>")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest("GET", tt.uri, nil)
+			rr := httptest.NewRecorder()
+
+			handler := RootHandler(tt.template, tt.version)
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.expectedStatus {
+				t.Errorf("got status %v, want %v", status, tt.expectedStatus)
+			}
+
+			if body := strings.TrimSpace(rr.Body.String()); body != tt.expectedBody {
+				t.Errorf("got %v, want %v", body, tt.expectedBody)
+			}
+		})
+	}
+}

--- a/handlers/middleware_test.go
+++ b/handlers/middleware_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMiddleware(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	middleware := Middleware(nextHandler)
+	rr := httptest.NewRecorder()
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(strings.Repeat("a", 1024)))
+	middleware.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("got %v, want %v", rr.Code, http.StatusOK)
+	}
+}
+
+func TestGetRemoteIp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xForwarded string
+		want       string
+	}{
+		{"Direct connection", "1.2.3.4:5678", "", "1.2.3.4"},
+		{"Forwarded", "127.0.0.1:80", "200.200.200.200, 1.1.1.1", "200.200.200.200"},
+		{"Malformed remote addr", "invalid-addr", "", "invalid-addr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := &http.Request{
+				Header:     http.Header{"X-Forwarded-For": []string{tt.xForwarded}},
+				RemoteAddr: tt.remoteAddr,
+			}
+			if got := GetRemoteIP(*req); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
+func TestGetSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"With source", "/?source=health-check", "health-check"},
+		{"Empty source", "/", ""},
+		{"Multiple params", "/?other=1&source=zig-vscode", "zig-vscode"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest("GET", tt.url, nil)
+			if got := GetSource(*req); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -14,7 +14,12 @@ func RedirectHandler(port int) http.HandlerFunc {
 			host = r.Host
 		}
 
-		targetURL := "https://" + host + ":" + strconv.Itoa(port) + r.URL.RequestURI()
+		portStr := ""
+		if port != 443 {
+			portStr = ":" + strconv.Itoa(port)
+		}
+
+		targetURL := "https://" + host + portStr + r.URL.RequestURI()
 
 		http.Redirect(w, r, targetURL, http.StatusMovedPermanently)
 	}

--- a/handlers/redirect_test.go
+++ b/handlers/redirect_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirectHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hostHeader   string
+		uri          string
+		port         int
+		wantLocation string
+	}{
+		{
+			name:         "Simple hostname",
+			hostHeader:   "example.com",
+			uri:          "/path/to/resource",
+			port:         8443,
+			wantLocation: "https://example.com:8443/path/to/resource",
+		},
+		{
+			name:         "Hostname with existing port",
+			hostHeader:   "example.com:80",
+			uri:          "/",
+			port:         8443,
+			wantLocation: "https://example.com:8443/",
+		},
+		{
+			name:         "IPv6 address",
+			hostHeader:   "[2001:db8::1]",
+			uri:          "/test",
+			port:         8443,
+			wantLocation: "https://[2001:db8::1]:8443/test",
+		},
+		{
+			name:         "Hostname with a zig artifact",
+			hostHeader:   "example.com",
+			uri:          "/zig-riscv64-linux-0.14.1.tar.xz",
+			port:         8443,
+			wantLocation: "https://example.com:8443/zig-riscv64-linux-0.14.1.tar.xz",
+		},
+		{
+			name:         "Redirect to 443 (omit port)",
+			hostHeader:   "example.com:8080",
+			uri:          "/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+			port:         443,
+			wantLocation: "https://example.com/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+		},
+		{
+			name:         "Redirect to 443 (omit port)",
+			hostHeader:   "example.com:80",
+			uri:          "/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+			port:         443,
+			wantLocation: "https://example.com/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+		},
+		{
+			name:         "Redirect to custom port (include port)",
+			hostHeader:   "example.com",
+			uri:          "/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+			port:         8443,
+			wantLocation: "https://example.com:8443/zig-riscv64-linux-0.14.1.tar.xz.minisig",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest("GET", tt.uri, nil)
+			req.Host = tt.hostHeader
+
+			rr := httptest.NewRecorder()
+			handler := RedirectHandler(tt.port)
+
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusMovedPermanently {
+				t.Errorf("got status %v, want %v", status, http.StatusMovedPermanently)
+			}
+
+			gotLocation := rr.Header().Get("Location")
+			if gotLocation != tt.wantLocation {
+				t.Errorf("got Location %v, want %v", gotLocation, tt.wantLocation)
+			}
+		})
+	}
+
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,9 +9,6 @@ import (
 	"strconv"
 )
 
-// MUST BE SET by go build -ldflags "-X main.version=999"
-var version string // git describe --tags --always --dirty
-
 // Config holds configuration values, populated from command-line flags.
 type Config struct {
 	CacheDir        string
@@ -58,7 +55,7 @@ func ParseConfig() (Config, error) {
 	flag.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
 	flag.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
 	flag.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
-	flag.IntVar(&c.ClearBuilds, "clear-builds-interval", 86400, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
+	flag.IntVar(&c.ClearBuilds, "clear-builds-interval", 345600, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
 
 	flag.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
 	flag.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")
@@ -135,6 +132,8 @@ func (c Config) HTTPSAddress() string {
 func (c *Config) AcceptTOS(tosURL string) bool {
 	if c.ACMEAcceptTOS {
 		c.acmeTOSURL = "Accepting ACME Terms of Service at: " + tosURL
+	} else {
+		c.acmeTOSURL = "Terms of Service are not accepted"
 	}
 	return c.ACMEAcceptTOS
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,17 +12,18 @@ import (
 
 // Config holds configuration values, populated from command-line flags.
 type Config struct {
-	CacheDir        string
-	UpstreamURL     string
-	HTTPPort        int
-	TLSPort         int
-	ListenAddress   string
-	EnableTLS       bool
-	RedirectToHTTPS bool
-	ShowVersion     bool
-	ShowIndexPage   bool
-	IndexPage       string
-	ClearBuilds     int
+	CacheDir         string
+	UpstreamURL      string
+	HTTPPort         int
+	TLSPort          int
+	ListenAddress    string
+	EnableTLS        bool
+	RedirectToHTTPS  bool
+	ShowVersion      bool
+	ShowPossibleSize bool
+	ShowIndexPage    bool
+	IndexPage        string
+	ClearBuilds      int
 
 	ACME          bool
 	ACMEDirectory string
@@ -60,9 +61,10 @@ func ParseConfig(args []string, errorHandling flag.ErrorHandling) (Config, error
 	fs.StringVar(&c.tlsKeyFile, "tls-key-file", "", "Path to the TLS private key file.")
 	fs.BoolVar(&c.RedirectToHTTPS, "redirect-to-https", false, "Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls or -acme.")
 	fs.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
+	fs.BoolVar(&c.ShowPossibleSize, "show-possible-size", false, "Print estimation stats of all cacheable upstream artifacts (size, release counts) and exit.")
 	fs.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
 	fs.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
-	fs.IntVar(&c.ClearBuilds, "clear-builds-interval", 345600, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
+	fs.IntVar(&c.ClearBuilds, "clear-builds-interval", 86400, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
 
 	fs.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
 	fs.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func ParseConfig(args []string, errorHandling flag.ErrorHandling) (Config, error
 	fs.BoolVar(&c.ShowPossibleSize, "show-possible-size", false, "Print estimation stats of all cacheable upstream artifacts (size, release counts) and exit.")
 	fs.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
 	fs.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
-	fs.IntVar(&c.ClearBuilds, "clear-builds-interval", 86400, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
+	fs.IntVar(&c.ClearBuilds, "clear-builds-interval", 7200, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
 
 	fs.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
 	fs.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 )
@@ -40,31 +41,40 @@ type Config struct {
 }
 
 // ParseConfig defines and parses command-line flags, validates them, and returns a populated Config struct.
-func ParseConfig() (Config, error) {
+func ParseConfig(args []string, errorHandling flag.ErrorHandling) (Config, error) {
 	var c Config
 
-	flag.StringVar(&c.CacheDir, "cache-dir", "./", "Path to the directory where downloaded content will be cached.")
-	flag.StringVar(&c.UpstreamURL, "upstream-url", "https://ziglang.org", "The URL of the upstream server to mirror/proxy.")
-	flag.IntVar(&c.HTTPPort, "http-port", 80, "The port for the plain HTTP listener.")
-	flag.IntVar(&c.TLSPort, "tls-port", 443, "The port for the secure TLS (HTTPS) listener.")
-	flag.StringVar(&c.ListenAddress, "listen-address", "", "The IP address to listen on. If empty, listens on all available interfaces.")
-	flag.BoolVar(&c.EnableTLS, "enable-tls", false, "Enable the TLS (HTTPS) server. Requires -tls-cert-file and -tls-key-file.")
-	flag.StringVar(&c.tlsCertFile, "tls-cert-file", "", "Path to the TLS certificate file.")
-	flag.StringVar(&c.tlsKeyFile, "tls-key-file", "", "Path to the TLS private key file.")
-	flag.BoolVar(&c.RedirectToHTTPS, "redirect-to-https", false, "Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls or -acme.")
-	flag.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
-	flag.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
-	flag.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
-	flag.IntVar(&c.ClearBuilds, "clear-builds-interval", 345600, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
+	fs := flag.NewFlagSet("go-mirror-zig", errorHandling)
 
-	flag.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
-	flag.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")
-	flag.BoolVar(&c.ACMEAcceptTOS, "acme-accept-tos", false, "Accept the ACME provider's Terms of Service.")
-	flag.StringVar(&c.ACMECache, "acme-cache", "", "Directory for storing obtained certificates.")
-	flag.StringVar(&c.ACMEEmail, "acme-email", "", "Email address for ACME registration and recovery notices.")
-	flag.StringVar(&c.ACMEHost, "acme-host", "", "The hostname (domain name) for which to obtain the ACME certificate.")
+	if errorHandling == flag.ContinueOnError {
+		fs.SetOutput(io.Discard) // suppress console text on tests
+	}
 
-	flag.Parse()
+	fs.StringVar(&c.CacheDir, "cache-dir", "./", "Path to the directory where downloaded content will be cached.")
+	fs.StringVar(&c.UpstreamURL, "upstream-url", "https://ziglang.org", "The URL of the upstream server to mirror/proxy.")
+	fs.IntVar(&c.HTTPPort, "http-port", 80, "The port for the plain HTTP listener.")
+	fs.IntVar(&c.TLSPort, "tls-port", 443, "The port for the secure TLS (HTTPS) listener.")
+	fs.StringVar(&c.ListenAddress, "listen-address", "", "The IP address to listen on. If empty, listens on all available interfaces.")
+	fs.BoolVar(&c.EnableTLS, "enable-tls", false, "Enable the TLS (HTTPS) server. Requires -tls-cert-file and -tls-key-file.")
+	fs.StringVar(&c.tlsCertFile, "tls-cert-file", "", "Path to the TLS certificate file.")
+	fs.StringVar(&c.tlsKeyFile, "tls-key-file", "", "Path to the TLS private key file.")
+	fs.BoolVar(&c.RedirectToHTTPS, "redirect-to-https", false, "Enable automatic redirection of HTTP requests to HTTPS. Requires -enable-tls or -acme.")
+	fs.BoolVar(&c.ShowVersion, "version", false, "Print version information and exit.")
+	fs.BoolVar(&c.ShowIndexPage, "show-index-page", true, "Whether to serve a custom index page at the root (/). Set to false to disable.")
+	fs.StringVar(&c.IndexPage, "index-page", "", "Path to a directory containing static files to serve as the root index. If empty, uses the default built-in index page.")
+	fs.IntVar(&c.ClearBuilds, "clear-builds-interval", 345600, "Interval in seconds to clean up cached dev builds. Set to 0 to disable.")
+
+	fs.BoolVar(&c.ACME, "acme", false, "Obtain TLS certificates using the ACME challenge.")
+	fs.StringVar(&c.ACMEDirectory, "acme-directory", "https://acme-v02.api.letsencrypt.org/directory", "ACME directory URL.")
+	fs.BoolVar(&c.ACMEAcceptTOS, "acme-accept-tos", false, "Accept the ACME provider's Terms of Service.")
+	fs.StringVar(&c.ACMECache, "acme-cache", "", "Directory for storing obtained certificates.")
+	fs.StringVar(&c.ACMEEmail, "acme-email", "", "Email address for ACME registration and recovery notices.")
+	fs.StringVar(&c.ACMEHost, "acme-host", "", "The hostname (domain name) for which to obtain the ACME certificate.")
+
+	err := fs.Parse(args)
+	if err != nil {
+		return c, err
+	}
 
 	if c.EnableTLS && c.ACME {
 		return c, errors.New("cannot use both -enable-tls (manual certificates) and -acme (automatic certificates) at the same time")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"testing"
 )
 
@@ -121,4 +122,56 @@ func TestAcceptTOS(t *testing.T) {
 		})
 	}
 
+}
+
+func TestParseConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantError bool
+	}{
+		{"defaults", []string{}, false},
+		{"TLS and ACME together", []string{"-enable-tls", "-acme"}, true},
+		{"TLS enabled without files", []string{"-enable-tls"}, true},
+		{"TLS enabled with missing key", []string{"-enable-tls", "-tls-cert-file", "cert.pem"}, true},
+		{"TLS enabled with non existent files", []string{"-enable-tls", "-tls-cert-file", "cert.pem", "-tls-key-file", "key.pem"}, true},
+		{"Redirect without TLS or ACME", []string{"-redirect-to-https"}, true},
+		{"Redirect with ACME (valid setup)", []string{
+			"-acme",
+			"-acme-accept-tos",
+			"-acme-cache", "/tmp/certs",
+			"-acme-email", "someone@example.com",
+			"-acme-host", "example.com",
+			"-redirect-to-https",
+		}, false},
+		{"ACME missing TOS", []string{"-acme", "-acme-cache", "/tmp", "-acme-email", "someone@example.com", "-acme-host", "example.com"}, true},
+		{"ACME missing cache", []string{"-acme", "-acme-accept-tos", "-acme-email", "someone@example.com", "-acme-host", "example.com"}, true},
+		{"ACME missing email", []string{"-acme", "-acme-accept-tos", "-acme-cache", "/tmp", "-acme-host", "example.com"}, true},
+		{"ACME missing host", []string{"-acme", "-acme-accept-tos", "-acme-cache", "/tmp", "-acme-email", "someone@example.com"}, true},
+		{"ACME full valid config", []string{
+			"-acme",
+			"-acme-accept-tos",
+			"-acme-cache", "/tmp/certs",
+			"-acme-email", "someone@example.com",
+			"-acme-host", "example.com",
+		}, false},
+		{"Negative clear builds interval", []string{"-clear-builds-interval", "-5"}, true},
+		{"Zero clear builds interval (valid)", []string{"-clear-builds-interval", "0"}, false},
+		{"Invalid flag name", []string{"-not-a-flag", "value"}, true},
+		{"Invalid port type", []string{"-http-port", "not-a-number"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseConfig(tt.args, flag.ContinueOnError)
+			if (err != nil) != tt.wantError {
+				t.Errorf("got error %v, want error %v", err, tt.wantError)
+				return
+			}
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestHTTPAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       Config
+		expected string
+	}{
+		{
+			name: "Localhost",
+			in: Config{
+				ListenAddress: "127.0.0.1",
+				HTTPPort:      80,
+			},
+			expected: "127.0.0.1:80",
+		},
+		{
+			name: "All IPs",
+			in: Config{
+				ListenAddress: "0.0.0.0",
+				HTTPPort:      8080,
+			},
+			expected: "0.0.0.0:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.in.HTTPAddress(); got != tt.expected {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+
+}
+
+func TestHTTPSAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       Config
+		expected string
+	}{
+		{
+			name: "Localhost",
+			in: Config{
+				ListenAddress: "127.0.0.1",
+				TLSPort:       443,
+			},
+			expected: "127.0.0.1:443",
+		},
+		{
+			name: "All IPs",
+			in: Config{
+				ListenAddress: "0.0.0.0",
+				TLSPort:       443,
+			},
+			expected: "0.0.0.0:443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.in.HTTPSAddress(); got != tt.expected {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+
+}
+
+func TestAcceptTOS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		in             Config
+		inTOSurl       string
+		expectedTOS    bool
+		expectedTOSMsg string
+	}{
+		{
+			name:           "TOS accepted",
+			in:             Config{ACMEAcceptTOS: true},
+			inTOSurl:       "lets-encrypt",
+			expectedTOS:    true,
+			expectedTOSMsg: "Accepting ACME Terms of Service at: lets-encrypt",
+		},
+		{
+			name:           "TOS isn't accepted",
+			in:             Config{ACMEAcceptTOS: false},
+			expectedTOS:    false,
+			expectedTOSMsg: "Terms of Service are not accepted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.in.AcceptTOS(tt.inTOSurl)
+
+			if tt.in.ACMEAcceptTOS != tt.expectedTOS {
+				t.Errorf("got %v, want %v", tt.in.ACMEAcceptTOS, tt.expectedTOS)
+			}
+
+			if got := tt.in.acmeTOSURL; got != tt.expectedTOSMsg {
+				t.Errorf("got %v, want %v", got, tt.expectedTOSMsg)
+			}
+		})
+	}
+
+}

--- a/internal/zig/client.go
+++ b/internal/zig/client.go
@@ -1,0 +1,40 @@
+package zig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Fetch the file with all Zig releases
+// Such file is usually located here: https://ziglang.org/download/index.json
+func FetchAllReleases(ctx context.Context, url string) (ZigReleases, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var zr ZigReleases
+	if err := json.Unmarshal(body, &zr); err != nil {
+		return nil, err
+	}
+
+	return zr, nil
+}

--- a/internal/zig/client_test.go
+++ b/internal/zig/client_test.go
@@ -1,0 +1,126 @@
+package zig
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchAllReleases(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/download/index.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		w.Write([]byte(`{
+			"master": {
+				"version": "0.17.0-dev.305+bdfbf432d",
+				"date": "2026-05-15",
+    			"docs": "https://ziglang.org/documentation/master/",
+    			"stdDocs": "https://ziglang.org/documentation/master/std/",
+				"src": {
+				  "tarball": "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+				  "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+				  "size": "22530120"
+				}
+			},
+            "0.16.0": {
+              "version": "0.16.0",
+              "date": "2026-04-13",
+              "docs": "https://ziglang.org/documentation/0.16.0/",
+              "stdDocs": "https://ziglang.org/documentation/0.16.0/std/",
+              "notes": "https://ziglang.org/download/0.16.0/release-notes.html",
+              "src": {
+                "tarball": "https://ziglang.org/download/0.16.0/zig-0.16.0.tar.xz",
+                "shasum": "43186959edc87d5c7a1be7b7d2a25efffd22ce5807c7af99067f86f99641bfdf",
+                "size": "22503260"
+              },
+              "bootstrap": {
+                "tarball": "https://ziglang.org/download/0.16.0/zig-bootstrap-0.16.0.tar.xz",
+                "shasum": "2a8266a4205772ef40838c8cbdf14875855a515ff3adf89b49c2d2ae93613d10",
+                "size": "55245980"
+              }
+			}
+		}`))
+	})
+
+	mux.HandleFunc("/download/bad-status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`Server Error`))
+	})
+
+	mux.HandleFunc("/download/invalid-json.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "master": INVALID JSON ]}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	tests := []struct {
+		name        string
+		url         string
+		ctx         func() context.Context
+		expectError bool
+	}{
+		{
+			name:        "successful fetch",
+			url:         ts.URL + "/download/index.json",
+			ctx:         func() context.Context { return context.Background() },
+			expectError: false,
+		},
+
+		{
+			name:        "server returns non 200 status",
+			url:         ts.URL + "/download/bad-status",
+			ctx:         func() context.Context { return context.Background() },
+			expectError: true,
+		},
+		{
+			name:        "server returns an invalid json",
+			url:         ts.URL + "/download/invalid-json.json",
+			ctx:         func() context.Context { return context.Background() },
+			expectError: true,
+		},
+		{
+			name:        "invalid url format",
+			url:         "://0.0.0.0",
+			ctx:         func() context.Context { return context.Background() },
+			expectError: true,
+		},
+		{
+			name: "canceled context",
+			url:  ts.URL + "/download/index.json",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := tt.ctx()
+			zr, err := FetchAllReleases(ctx, tt.url)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("did not expect an error, but got: %v", err)
+			}
+
+			if len(zr) == 0 {
+				t.Fatalf("expected parsed ZigReleases, got empty or nil")
+			}
+		})
+	}
+}

--- a/internal/zig/json.go
+++ b/internal/zig/json.go
@@ -1,0 +1,42 @@
+package zig
+
+import "encoding/json"
+
+// Convert index.json (the file with all Zig releases) to the ZigReleases structure
+// It omits all artifacts without a tarball
+func (r *Release) UnmarshalJSON(data []byte) error {
+	type Alias Release
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// See: https://stackoverflow.com/a/53352532
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	r.Platforms = make(map[string]Artifact)
+
+	for key, val := range raw {
+		switch key {
+		case "version", "date", "docs", "stdDocs", "notes":
+			continue
+		default:
+			var artifact Artifact
+			if err := json.Unmarshal(val, &artifact); err == nil {
+				// Omitting artifacts without a tarball
+				if artifact.Tarball != "" {
+					r.Platforms[key] = artifact
+				}
+			}
+		}
+
+	}
+	return nil
+}

--- a/internal/zig/json_test.go
+++ b/internal/zig/json_test.go
@@ -1,0 +1,308 @@
+package zig
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestZigReleases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inputJSON     string
+		expectError   bool
+		expected      ZigReleases
+		expectedTotal int
+	}{
+		{
+			name:          "empty json object",
+			inputJSON:     `{}`,
+			expectError:   false,
+			expected:      ZigReleases{},
+			expectedTotal: 0,
+		},
+		{
+			name:        "invalid json",
+			inputJSON:   `{ not valid json }`,
+			expectError: true,
+			expected:    nil,
+		},
+		{
+			name: "dev branch, no artifacts",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/"
+  				}
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version:   "0.17.0-dev.305+bdfbf432d",
+					Date:      "2026-05-15",
+					Docs:      "https://ziglang.org/documentation/master/",
+					StdDocs:   "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{},
+				},
+			},
+		},
+		{
+			name: "dev branch, single artifact",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/",
+  				  "src": {
+  				    "tarball": "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+  				    "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+  				    "size": "22530120"
+  				  }
+  				}
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version: "0.17.0-dev.305+bdfbf432d",
+					Date:    "2026-05-15",
+					Docs:    "https://ziglang.org/documentation/master/",
+					StdDocs: "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{
+						"src": {
+							Tarball: "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+							Size:    "22530120",
+						},
+					},
+				},
+			},
+			expectedTotal: 22530120,
+		},
+		{
+			name: "dev branch, multiple artifacts",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/",
+  				  "src": {
+  				    "tarball": "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+  				    "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+  				    "size": "22530120"
+  				  },
+    			  "bootstrap": {
+    			    "tarball": "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+    			    "shasum": "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+    			    "size": "56523612"
+    			  }
+  				}
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version: "0.17.0-dev.305+bdfbf432d",
+					Date:    "2026-05-15",
+					Docs:    "https://ziglang.org/documentation/master/",
+					StdDocs: "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{
+						"src": {
+							Tarball: "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+							Size:    "22530120",
+						},
+						"bootstrap": {
+							Tarball: "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+							Size:    "56523612",
+						},
+					},
+				},
+			},
+			expectedTotal: 22530120 + 56523612,
+		},
+		{
+			name: "dev branch, omit artifacts without tarballs",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/",
+  				  "src": {
+  				    "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+  				    "size": "22530120"
+  				  },
+    			  "bootstrap": {
+    			    "shasum": "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+    			    "size": "56523612"
+    			  }
+  				}
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version:   "0.17.0-dev.305+bdfbf432d",
+					Date:      "2026-05-15",
+					Docs:      "https://ziglang.org/documentation/master/",
+					StdDocs:   "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{},
+				},
+			},
+		},
+		{
+			name: "dev branch, single artifact, wrong size",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/",
+  				  "src": {
+  				    "tarball": "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+  				    "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+  				    "size": "22530120"
+  				  },
+    			  "bootstrap": {
+    			    "tarball": "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+    			    "shasum": "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+    			    "size": "it-is-not-a-number"
+    			  }
+  				}
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version: "0.17.0-dev.305+bdfbf432d",
+					Date:    "2026-05-15",
+					Docs:    "https://ziglang.org/documentation/master/",
+					StdDocs: "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{
+						"src": {
+							Tarball: "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+							Size:    "22530120",
+						},
+						"bootstrap": {
+							Tarball: "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+							Size:    "it-is-not-a-number",
+						},
+					},
+				},
+			},
+			expectedTotal: 22530120,
+		},
+
+		{
+			name: "dev branch and a release, multiple artifacts",
+			inputJSON: `{
+  				"master": {
+  				  "version": "0.17.0-dev.305+bdfbf432d",
+  				  "date": "2026-05-15",
+  				  "docs": "https://ziglang.org/documentation/master/",
+  				  "stdDocs": "https://ziglang.org/documentation/master/std/",
+  				  "src": {
+  				    "tarball": "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+  				    "shasum": "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+  				    "size": "22530120"
+  				  },
+    			  "bootstrap": {
+    			    "tarball": "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+    			    "shasum": "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+    			    "size": "56523612"
+    			  }
+  				},
+                "0.16.0": {
+                  "version": "0.16.0",
+                  "date": "2026-04-13",
+                  "docs": "https://ziglang.org/documentation/0.16.0/",
+                  "stdDocs": "https://ziglang.org/documentation/0.16.0/std/",
+                  "notes": "https://ziglang.org/download/0.16.0/release-notes.html",
+                  "src": {
+                    "tarball": "https://ziglang.org/download/0.16.0/zig-0.16.0.tar.xz",
+                    "shasum": "43186959edc87d5c7a1be7b7d2a25efffd22ce5807c7af99067f86f99641bfdf",
+                    "size": "22503260"
+                  },
+                  "bootstrap": {
+                    "tarball": "https://ziglang.org/download/0.16.0/zig-bootstrap-0.16.0.tar.xz",
+                    "shasum": "2a8266a4205772ef40838c8cbdf14875855a515ff3adf89b49c2d2ae93613d10",
+                    "size": "55245980"
+                  }
+                }
+			}`,
+			expectError: false,
+			expected: ZigReleases{
+				"master": {
+					Version: "0.17.0-dev.305+bdfbf432d",
+					Date:    "2026-05-15",
+					Docs:    "https://ziglang.org/documentation/master/",
+					StdDocs: "https://ziglang.org/documentation/master/std/",
+					Platforms: map[string]Artifact{
+						"src": {
+							Tarball: "https://ziglang.org/builds/zig-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f4e02500223c65225cb98651d32f744ee1f8939db05c4718598f1d89eddaa5dd",
+							Size:    "22530120",
+						},
+						"bootstrap": {
+							Tarball: "https://ziglang.org/builds/zig-bootstrap-0.17.0-dev.305+bdfbf432d.tar.xz",
+							Shasum:  "f458a74d58561e185b69527a80b7f9aeeb721d6f824e293286a48c6fdb047f52",
+							Size:    "56523612",
+						},
+					},
+				},
+				"0.16.0": {
+					Version: "0.16.0",
+					Date:    "2026-04-13",
+					Docs:    "https://ziglang.org/documentation/0.16.0/",
+					StdDocs: "https://ziglang.org/documentation/0.16.0/std/",
+					Notes:   "https://ziglang.org/download/0.16.0/release-notes.html",
+					Platforms: map[string]Artifact{
+						"src": {
+							Tarball: "https://ziglang.org/download/0.16.0/zig-0.16.0.tar.xz",
+							Shasum:  "43186959edc87d5c7a1be7b7d2a25efffd22ce5807c7af99067f86f99641bfdf",
+							Size:    "22503260",
+						},
+						"bootstrap": {
+							Tarball: "https://ziglang.org/download/0.16.0/zig-bootstrap-0.16.0.tar.xz",
+							Shasum:  "2a8266a4205772ef40838c8cbdf14875855a515ff3adf89b49c2d2ae93613d10",
+							Size:    "55245980",
+						},
+					},
+				},
+			},
+			expectedTotal: 22530120 + 56523612 + 22503260 + 55245980,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var zr ZigReleases
+			err := json.Unmarshal([]byte(tt.inputJSON), &zr)
+
+			if (err != nil) != tt.expectError {
+				t.Fatalf("expected error: %v, got: %v", tt.expectError, err)
+			}
+
+			if tt.expectError {
+				return
+			}
+
+			if !reflect.DeepEqual(zr, tt.expected) {
+				t.Errorf("\nExpected: %#v\nGot:      %#v", tt.expected, zr)
+			}
+
+			actualTotal := TotalSize(zr)
+			if actualTotal != tt.expectedTotal {
+				t.Errorf("TotalSize: expected %d, got %d", tt.expectedTotal, actualTotal)
+			}
+		})
+	}
+}

--- a/internal/zig/zig.go
+++ b/internal/zig/zig.go
@@ -1,6 +1,9 @@
 package zig
 
-import "regexp"
+import (
+	"regexp"
+	"strconv"
+)
 
 // Matches standard Zig distribution filenames, capturing the version string.
 var filenameRegex = regexp.MustCompile(`^zig(?:|-bootstrap|-[a-zA-Z0-9_]+-[a-zA-Z0-9_]+)-(\d+\.\d+\.\d+(?:-dev\.\d+\+[0-9a-f]+)?)\.(?:tar\.xz|zip)(?:\.minisig)?$`)
@@ -24,4 +27,39 @@ func ArtifactSubmatches(s string) []string {
 	}
 
 	return matches
+}
+
+// A Zig artifact from index.json
+type Artifact struct {
+	Tarball string
+	Shasum  string
+	Size    string
+}
+
+// A Zig release from index.json
+type Release struct {
+	Version   string              `json:"version"`
+	Date      string              `json:"date"`
+	Docs      string              `json:"docs"`
+	StdDocs   string              `json:"stdDocs"`
+	Notes     string              `json:"notes"`
+	Platforms map[string]Artifact `json:"-"`
+}
+
+// All releases and artifacts (including the dev branch one)
+type ZigReleases map[string]Release
+
+// Total size of all Zig artifacts
+func TotalSize(zr ZigReleases) int {
+	total := 0
+	for _, release := range zr {
+		for _, artifact := range release.Platforms {
+			i, err := strconv.Atoi(artifact.Size)
+			if err != nil {
+				continue
+			}
+			total += i
+		}
+	}
+	return total
 }

--- a/internal/zig/zig_test.go
+++ b/internal/zig/zig_test.go
@@ -1,0 +1,145 @@
+package zig
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestIsZigArtifact(t *testing.T) {
+	t.Parallel()
+
+	var zigArtifacts = []struct {
+		in       string
+		expected bool
+	}{
+		{"", false},
+		{"zig", false},
+		{"zig-0.14.1.tarxz", false},
+		{"zig-0.14.1.tar .xz", false},
+
+		// See:
+		// https://github.com/ziglang/www.ziglang.org/blob/main/check-mirrors/main.zig
+		{"zig-0.14.1.tar.xz", true},
+		{"zig-x86_64-windows-0.14.1.zip", true},
+		{"zig-aarch64-macos-0.14.1.tar.xz", true},
+		{"zig-x86_64-linux-0.14.1.tar.xz", true},
+		{"zig-aarch64-linux-0.14.1.tar.xz", true},
+		{"zig-armv7a-linux-0.14.1.tar.xz", true},
+		{"zig-riscv64-linux-0.14.1.tar.xz", true},
+		{"zig-powerpc64le-linux-0.14.1.tar.xz", true},
+		{"zig-x86-linux-0.14.1.tar.xz", true},
+		{"zig-loongarch64-linux-0.14.1.tar.xz", true},
+		{"zig-s390x-linux-0.14.1.tar.xz", true},
+		{"zig-0.10.1.tar.xz", true},
+		{"zig-bootstrap-0.10.1.tar.xz", true},
+		{"zig-linux-i386-0.10.1.tar.xz", true},
+		{"zig-macos-aarch64-0.10.1.tar.xz", true},
+		{"zig-windows-x86_64-0.10.1.zip", true},
+		{"zig-0.7.1.tar.xz", true},
+		{"zig-linux-x86_64-0.7.1.tar.xz", true},
+		{"zig-0.6.0.tar.xz", true},
+		{"zig-linux-x86_64-0.6.0.tar.xz", true},
+
+		// With .minisig
+		{"zig-0.14.1.tar.xz.minisig", true},
+		{"zig-x86_64-windows-0.14.1.zip.minisig", true},
+		{"zig-aarch64-macos-0.14.1.tar.xz.minisig", true},
+		{"zig-x86_64-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-aarch64-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-armv7a-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-riscv64-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-powerpc64le-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-x86-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-loongarch64-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-s390x-linux-0.14.1.tar.xz.minisig", true},
+		{"zig-0.10.1.tar.xz.minisig", true},
+		{"zig-bootstrap-0.10.1.tar.xz.minisig", true},
+		{"zig-linux-i386-0.10.1.tar.xz.minisig", true},
+		{"zig-macos-aarch64-0.10.1.tar.xz.minisig", true},
+		{"zig-windows-x86_64-0.10.1.zip.minisig", true},
+		{"zig-0.7.1.tar.xz.minisig", true},
+		{"zig-linux-x86_64-0.7.1.tar.xz.minisig", true},
+		{"zig-0.6.0.tar.xz.minisig", true},
+		{"zig-linux-x86_64-0.6.0.tar.xz.minisig", true},
+	}
+
+	for _, tt := range zigArtifacts {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			check := IsZigArtifact(tt.in)
+			if check != tt.expected {
+				t.Errorf("got %v, want %v", check, tt.expected)
+			}
+		})
+	}
+}
+
+func TestArtifactSubmatches(t *testing.T) {
+	t.Parallel()
+
+	var zigArtifacts = []struct {
+		in       string
+		expected []string
+	}{
+		{"", nil},
+		{"zig", nil},
+		{"zig-0.14.1.tarxz", nil},
+		{"zig-0.14.1.tar .xz", nil},
+
+		// See:
+		// https://github.com/ziglang/www.ziglang.org/blob/main/check-mirrors/main.zig
+		{"zig-0.14.1.tar.xz", []string{"zig-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-x86_64-windows-0.14.1.zip", []string{"zig-x86_64-windows-0.14.1.zip", "0.14.1"}},
+		{"zig-aarch64-macos-0.14.1.tar.xz", []string{"zig-aarch64-macos-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-x86_64-linux-0.14.1.tar.xz", []string{"zig-x86_64-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-aarch64-linux-0.14.1.tar.xz", []string{"zig-aarch64-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-armv7a-linux-0.14.1.tar.xz", []string{"zig-armv7a-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-riscv64-linux-0.14.1.tar.xz", []string{"zig-riscv64-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-powerpc64le-linux-0.14.1.tar.xz", []string{"zig-powerpc64le-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-x86-linux-0.14.1.tar.xz", []string{"zig-x86-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-loongarch64-linux-0.14.1.tar.xz", []string{"zig-loongarch64-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-s390x-linux-0.14.1.tar.xz", []string{"zig-s390x-linux-0.14.1.tar.xz", "0.14.1"}},
+		{"zig-0.10.1.tar.xz", []string{"zig-0.10.1.tar.xz", "0.10.1"}},
+		{"zig-bootstrap-0.10.1.tar.xz", []string{"zig-bootstrap-0.10.1.tar.xz", "0.10.1"}},
+		{"zig-linux-i386-0.10.1.tar.xz", []string{"zig-linux-i386-0.10.1.tar.xz", "0.10.1"}},
+		{"zig-macos-aarch64-0.10.1.tar.xz", []string{"zig-macos-aarch64-0.10.1.tar.xz", "0.10.1"}},
+		{"zig-windows-x86_64-0.10.1.zip", []string{"zig-windows-x86_64-0.10.1.zip", "0.10.1"}},
+		{"zig-0.7.1.tar.xz", []string{"zig-0.7.1.tar.xz", "0.7.1"}},
+		{"zig-linux-x86_64-0.7.1.tar.xz", []string{"zig-linux-x86_64-0.7.1.tar.xz", "0.7.1"}},
+		{"zig-0.6.0.tar.xz", []string{"zig-0.6.0.tar.xz", "0.6.0"}},
+		{"zig-linux-x86_64-0.6.0.tar.xz", []string{"zig-linux-x86_64-0.6.0.tar.xz", "0.6.0"}},
+
+		// With .minisig
+		{"zig-0.14.1.tar.xz.minisig", []string{"zig-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-x86_64-windows-0.14.1.zip.minisig", []string{"zig-x86_64-windows-0.14.1.zip.minisig", "0.14.1"}},
+		{"zig-aarch64-macos-0.14.1.tar.xz.minisig", []string{"zig-aarch64-macos-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-x86_64-linux-0.14.1.tar.xz.minisig", []string{"zig-x86_64-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-aarch64-linux-0.14.1.tar.xz.minisig", []string{"zig-aarch64-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-armv7a-linux-0.14.1.tar.xz.minisig", []string{"zig-armv7a-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-riscv64-linux-0.14.1.tar.xz.minisig", []string{"zig-riscv64-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-powerpc64le-linux-0.14.1.tar.xz.minisig", []string{"zig-powerpc64le-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-x86-linux-0.14.1.tar.xz.minisig", []string{"zig-x86-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-loongarch64-linux-0.14.1.tar.xz.minisig", []string{"zig-loongarch64-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-s390x-linux-0.14.1.tar.xz.minisig", []string{"zig-s390x-linux-0.14.1.tar.xz.minisig", "0.14.1"}},
+		{"zig-0.10.1.tar.xz.minisig", []string{"zig-0.10.1.tar.xz.minisig", "0.10.1"}},
+		{"zig-bootstrap-0.10.1.tar.xz.minisig", []string{"zig-bootstrap-0.10.1.tar.xz.minisig", "0.10.1"}},
+		{"zig-linux-i386-0.10.1.tar.xz.minisig", []string{"zig-linux-i386-0.10.1.tar.xz.minisig", "0.10.1"}},
+		{"zig-macos-aarch64-0.10.1.tar.xz.minisig", []string{"zig-macos-aarch64-0.10.1.tar.xz.minisig", "0.10.1"}},
+		{"zig-windows-x86_64-0.10.1.zip.minisig", []string{"zig-windows-x86_64-0.10.1.zip.minisig", "0.10.1"}},
+		{"zig-0.7.1.tar.xz.minisig", []string{"zig-0.7.1.tar.xz.minisig", "0.7.1"}},
+		{"zig-linux-x86_64-0.7.1.tar.xz.minisig", []string{"zig-linux-x86_64-0.7.1.tar.xz.minisig", "0.7.1"}},
+		{"zig-0.6.0.tar.xz.minisig", []string{"zig-0.6.0.tar.xz.minisig", "0.6.0"}},
+		{"zig-linux-x86_64-0.6.0.tar.xz.minisig", []string{"zig-linux-x86_64-0.6.0.tar.xz.minisig", "0.6.0"}},
+	}
+
+	for _, tt := range zigArtifacts {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			check := ArtifactSubmatches(tt.in)
+
+			if !slices.Equal(check, tt.expected) {
+				t.Errorf("got %v, want %v", check, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/zig/zig_test.go
+++ b/internal/zig/zig_test.go
@@ -18,7 +18,14 @@ func TestIsZigArtifact(t *testing.T) {
 		{"zig-0.14.1.tar .xz", false},
 
 		// See:
-		// https://github.com/ziglang/www.ziglang.org/blob/main/check-mirrors/main.zig
+		// https://codeberg.org/ziglang/ziglang.org/src/branch/main/check-mirrors/main.zig
+		{"zig-arm-linux-0.16.0.tar.xz", true},
+		{"zig-riscv64-linux-0.16.0.tar.xz", true},
+		{"zig-loongarch64-linux-0.16.0.tar.xz", true},
+		{"zig-powerpc64le-freebsd-0.16.0.tar.xz", true},
+		{"zig-aarch64-netbsd-0.16.0.tar.xz", true},
+		{"zig-arm-openbsd-0.16.0.tar.xz", true},
+
 		{"zig-0.14.1.tar.xz", true},
 		{"zig-x86_64-windows-0.14.1.zip", true},
 		{"zig-aarch64-macos-0.14.1.tar.xz", true},
@@ -41,6 +48,13 @@ func TestIsZigArtifact(t *testing.T) {
 		{"zig-linux-x86_64-0.6.0.tar.xz", true},
 
 		// With .minisig
+		{"zig-arm-linux-0.16.0.tar.xz.minisig", true},
+		{"zig-riscv64-linux-0.16.0.tar.xz.minisig", true},
+		{"zig-loongarch64-linux-0.16.0.tar.xz.minisig", true},
+		{"zig-powerpc64le-freebsd-0.16.0.tar.xz.minisig", true},
+		{"zig-aarch64-netbsd-0.16.0.tar.xz.minisig", true},
+		{"zig-arm-openbsd-0.16.0.tar.xz.minisig", true},
+
 		{"zig-0.14.1.tar.xz.minisig", true},
 		{"zig-x86_64-windows-0.14.1.zip.minisig", true},
 		{"zig-aarch64-macos-0.14.1.tar.xz.minisig", true},
@@ -87,7 +101,14 @@ func TestArtifactSubmatches(t *testing.T) {
 		{"zig-0.14.1.tar .xz", nil},
 
 		// See:
-		// https://github.com/ziglang/www.ziglang.org/blob/main/check-mirrors/main.zig
+		// https://codeberg.org/ziglang/ziglang.org/src/branch/main/check-mirrors/main.zig
+		{"zig-arm-linux-0.16.0.tar.xz", []string{"zig-arm-linux-0.16.0.tar.xz", "0.16.0"}},
+		{"zig-riscv64-linux-0.16.0.tar.xz", []string{"zig-riscv64-linux-0.16.0.tar.xz", "0.16.0"}},
+		{"zig-loongarch64-linux-0.16.0.tar.xz", []string{"zig-loongarch64-linux-0.16.0.tar.xz", "0.16.0"}},
+		{"zig-powerpc64le-freebsd-0.16.0.tar.xz", []string{"zig-powerpc64le-freebsd-0.16.0.tar.xz", "0.16.0"}},
+		{"zig-aarch64-netbsd-0.16.0.tar.xz", []string{"zig-aarch64-netbsd-0.16.0.tar.xz", "0.16.0"}},
+		{"zig-arm-openbsd-0.16.0.tar.xz", []string{"zig-arm-openbsd-0.16.0.tar.xz", "0.16.0"}},
+
 		{"zig-0.14.1.tar.xz", []string{"zig-0.14.1.tar.xz", "0.14.1"}},
 		{"zig-x86_64-windows-0.14.1.zip", []string{"zig-x86_64-windows-0.14.1.zip", "0.14.1"}},
 		{"zig-aarch64-macos-0.14.1.tar.xz", []string{"zig-aarch64-macos-0.14.1.tar.xz", "0.14.1"}},
@@ -110,6 +131,13 @@ func TestArtifactSubmatches(t *testing.T) {
 		{"zig-linux-x86_64-0.6.0.tar.xz", []string{"zig-linux-x86_64-0.6.0.tar.xz", "0.6.0"}},
 
 		// With .minisig
+		{"zig-arm-linux-0.16.0.tar.xz.minisig", []string{"zig-arm-linux-0.16.0.tar.xz.minisig", "0.16.0"}},
+		{"zig-riscv64-linux-0.16.0.tar.xz.minisig", []string{"zig-riscv64-linux-0.16.0.tar.xz.minisig", "0.16.0"}},
+		{"zig-loongarch64-linux-0.16.0.tar.xz.minisig", []string{"zig-loongarch64-linux-0.16.0.tar.xz.minisig", "0.16.0"}},
+		{"zig-powerpc64le-freebsd-0.16.0.tar.xz.minisig", []string{"zig-powerpc64le-freebsd-0.16.0.tar.xz.minisig", "0.16.0"}},
+		{"zig-aarch64-netbsd-0.16.0.tar.xz.minisig", []string{"zig-aarch64-netbsd-0.16.0.tar.xz.minisig", "0.16.0"}},
+		{"zig-arm-openbsd-0.16.0.tar.xz.minisig", []string{"zig-arm-openbsd-0.16.0.tar.xz.minisig", "0.16.0"}},
+
 		{"zig-0.14.1.tar.xz.minisig", []string{"zig-0.14.1.tar.xz.minisig", "0.14.1"}},
 		{"zig-x86_64-windows-0.14.1.zip.minisig", []string{"zig-x86_64-windows-0.14.1.zip.minisig", "0.14.1"}},
 		{"zig-aarch64-macos-0.14.1.tar.xz.minisig", []string{"zig-aarch64-macos-0.14.1.tar.xz.minisig", "0.14.1"}},
@@ -139,6 +167,74 @@ func TestArtifactSubmatches(t *testing.T) {
 
 			if !slices.Equal(check, tt.expected) {
 				t.Errorf("got %v, want %v", check, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTotalSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    ZigReleases
+		expected int
+	}{
+		{
+			name:     "no releases",
+			input:    nil,
+			expected: 0,
+		},
+		{
+			name: "no artifacts",
+			input: ZigReleases{
+				"master": Release{
+					Version:   "0.17.0-dev.305+bdfbf432d",
+					Platforms: map[string]Artifact{},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "valid sizes across multiple releases and platforms",
+			input: ZigReleases{
+				"master": Release{
+					Platforms: map[string]Artifact{
+						"src":       {Size: "22530120"},
+						"bootstrap": {Size: "56523612"},
+					},
+				},
+				"0.16.0": Release{
+					Platforms: map[string]Artifact{
+						"src":       {Size: "22503260"},
+						"bootstrap": {Size: "55245980"},
+					},
+				},
+			},
+			expected: 22530120 + 56523612 + 22503260 + 55245980,
+		},
+
+		{
+			name: "mixed valid and invalid size strings",
+			input: ZigReleases{
+				"master": Release{
+					Platforms: map[string]Artifact{
+						"src":           {Size: "22530120"},
+						"bootstrap":     {Size: "not-valid"},
+						"riscv64-linux": {Size: "57027896"},
+					},
+				},
+			},
+			expected: 22530120 + 57027896,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := TotalSize(tt.input)
+			if actual != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
## [1.2.6] - 2026-05-19
### Added
- Added test suites for the index, middleware, redirect, and configuration parser handlers.
- Added unit tests for Zig internal logic in `internal/zig/zig.go`.
- Added a deployment subsection to the README for using Nginx as a reverse proxy.
- Added a direct link to the Zig Programming Language website in the README header.
- Added functionality to fetch and parse the upstream `index.json` for release processing.
- Added a function to calculate the total cacheable size of all upstream Zig artifacts.
- Added the `-show-possible-size` flag to display upstream artifact statistics (total size, release counts, and median sizes) before exiting.
- Added intelligent periodic cache cleanup that cross-references the local cache with the upstream `index.json` to preserve active `master` builds while removing stale ones.
- Added aggregate logging for the cleanup task, reporting the total number of files removed and space reclaimed (in bytes).
- Added new targets to the build script:
    - `linux/riscv64`
    - `linux/386`
    - `linux/ppc64le`
    - `linux/loong64`
    - `windows/arm64`
    - `freebsd/amd64`
    - `freebsd/arm64`
    - `netbsd/amd64`
    - `netbsd/arm64`
    - `openbsd/amd64`
    - `openbsd/arm64`

### Fixed
- Fixed inconsistent behavior of temporary files across platforms (Windows vs. Linux file locking). On Linux it is allowed to delete an opened file, while on Windows it is not allowed
- Added a warning message when ACME Terms of Service are not explicitly accepted.
- Removed an unused version string from the `config` package.
- Corrected the documentation regarding the default interval for cleaning up cached dev builds.
- Fixed grammar in the changelog.

### Changed
- Replaced GitHub links with Codeberg links for the official Zig main repository.
- The HTTP to HTTPS redirect now omits the `443` port if it's not required
- Reduced the interval in seconds to clean up cached dev builds (from 1 day to 2 hours), thanks to the intelligent periodic cache cleanup feature.
- Updated table driven tests for artifact regex matching.
- Improved the configuration parser tests.
- Updated readme.