### PR TITLE
Version 1.2.7 (security fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.7] - 2026-07-20
 ### Security
 - Updated the `golang.org/x/crypto` library (`v0.49.0` -> `v0.54.0`) (thanks Dependabot for that)
 - Updated the `golang.org/x/net` library (`v0.52.0` -> `v0.57.0`)


### PR DESCRIPTION
## [1.2.7] - 2026-07-20
### Security
- Updated the `golang.org/x/crypto` library (`v0.49.0` -> `v0.54.0`) (thanks Dependabot for that)
- Updated the `golang.org/x/net` library (`v0.52.0` -> `v0.57.0`)
- Updated the `golang.org/x/text` library (`v0.35.0` -> `v0.40.0`)

### Changed
- Removed the Go Report Card badge from the readme (the Go Report Card project was retired)
- Changed some text in the readme.